### PR TITLE
Add async test result support resolves #33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 *.iml
+.idea

--- a/jvm/src/main/scala/utest/runner/JvmRunner.scala
+++ b/jvm/src/main/scala/utest/runner/JvmRunner.scala
@@ -1,15 +1,10 @@
 package utest.runner
 
-import utest.toTestSeq
 import sbt.testing._
-import sbt.testing
-import collection.mutable
-import utest.framework.{TestTreeSeq, TestSuite, Result}
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-import scala.concurrent.ExecutionContext.Implicits.global
-import utest.util.{ArgParse, Tree}
-import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext
+import utest.ExecutionContext
+import utest.framework.TestSuite
+
+import scala.util.{Failure, Success}
 
 class JvmRunner(val args: Array[String],
                 val remoteArgs: Array[String])
@@ -18,7 +13,7 @@ class JvmRunner(val args: Array[String],
   def doStuff(s: Seq[String], loggers: Seq[Logger], name: String) = {
     val cls = Class.forName(name + "$")
     val suite = cls.getField("MODULE$").get(cls).asInstanceOf[TestSuite]
-    val res = utest.runSuite(
+    utest.runSuite(
       suite,
       s.toArray,
       args,
@@ -26,9 +21,11 @@ class JvmRunner(val args: Array[String],
       msg => loggers.foreach(_.info(progressString + name + "" + msg)),
       msg => addFailure(progressString + name + "" + msg),
       s => total.addAndGet(s.toInt)
-    )
+    ).onComplete {
+      case Failure(ex) => throw ex
+      case Success(res) => addResult(res)
+    } (ExecutionContext.RunNow)
 
-    addResult(res)
   }
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,8 +1,6 @@
 import sbt._
 import Keys._
 import scala.scalajs.sbtplugin.env.nodejs.NodeJSEnv
-import scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv
-import scala.scalajs.sbtplugin.env.rhino.RhinoJSEnv
 import scala.scalajs.sbtplugin.ScalaJSPlugin._
 
 import scala.scalajs.sbtplugin.ScalaJSPlugin.ScalaJSKeys._

--- a/shared/main/scala/utest/ExecutionContext.scala
+++ b/shared/main/scala/utest/ExecutionContext.scala
@@ -12,11 +12,15 @@ object ExecutionContext{
    */
   implicit object RunNow extends scala.concurrent.ExecutionContext {
     def execute(runnable: Runnable) =
-      try   { runnable.run() }
-      catch { case t: Throwable => reportFailure(t) }
+      try {
+        runnable.run()
+      } catch {
+        case ae: AssertionError => throw ae
+        case t: Throwable => reportFailure(t)
+      }
 
     def reportFailure(t: Throwable) = {
-      Console.err.println("Failure in async execution: " + t)
+      Console.err.println("Failure in RunNow async execution: " + t)
       Console.err.println(t.getStackTraceString)
     }
   }

--- a/shared/test/scala/utest/FrameworkAsyncTests.scala
+++ b/shared/test/scala/utest/FrameworkAsyncTests.scala
@@ -1,0 +1,31 @@
+package utest
+
+import scala.concurrent.Future
+
+object FrameworkAsyncTests extends TestSuite{
+  implicit val ec = utest.ExecutionContext.RunNow
+
+  def tests = TestSuite{
+
+    'asyncFailures {
+      val tests = TestSuite {
+        "testSuccess" - {
+          Future {
+            assert(true)
+          }
+        }
+        "testFail" - {
+          Future {
+            assert(false)
+          }
+        }
+      }
+
+      tests.runAsync().map {
+        results =>
+          assert(results.toSeq.head.value.isSuccess)
+          assert(results.toSeq.last.value.isFailure)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi, I got it all working, there were a lot of unused imports, so I optimized them. There is just one rule, async test must always return Future, otherwise no async stuff can be done. That includes utest testing its own results.
