### PR TITLE
Future returned from a test might contain just a value instead of Try monad

### DIFF
--- a/js/shared/main/scala/utest/framework/Formatter.scala
+++ b/js/shared/main/scala/utest/framework/Formatter.scala
@@ -60,8 +60,11 @@ class DefaultFormatter(color: Boolean = true,
   }
 
   def format(results: Tree[Result]): String = {
+    def errorFormatter(ex: Throwable): String =
+      s"Failure('$ex'${Option(ex.getCause).fold("")(cause => s" caused by '$cause'")})"
+
     results.map(r =>
-      r.name + "\t\t" + prettyTruncate(r, e => s"Failure ${e.getClass.getName}", r => (" " * r.name.length))
+      r.name + "\t\t" + prettyTruncate(r, errorFormatter, r => (" " * r.name.length))
     ).reduce(_ + _.map("\n" + _).mkString.replace("\n", "\n    "))
   }
 }


### PR DESCRIPTION
[Details](https://github.com/lihaoyi/utest/issues/33#issuecomment-62595997)

This is a bug that is revealed by scala-js 0.6.0-SNAPSHOT