### PR TITLE
Bump to Scala.js 0.6.0-M3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,7 @@ object Build extends sbt.Build{
                              .settings(sharedSettings:_*)
                              .settings(
 
-    addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M1"),
+    addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M3"),
     libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",
     name := "utest-js-plugin",
     sbtPlugin := true

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.0-M3")
 
 /* uTest uses itself to test itself. At the library level, this is not a
  * problem. But the runner must be available to the build project. So we
@@ -8,7 +8,3 @@ unmanagedSources in Compile ++= {
   val root = baseDirectory.value.getParentFile
   ((root / "runner" * "*.scala") +++ (root / "jsPlugin" * "*.scala")).get
 }
-
-resolvers += Resolver.url("scala-js-releases",
-  url("http://dl.bintray.com/scala-js/scala-js-releases/"))(
-    Resolver.ivyStylePatterns)


### PR DESCRIPTION
The resolver is not needed anymore as Scala.js is pushed to
Maven Central.