### PR TITLE
Async testing

### DIFF
--- a/js/shared/main/scala/utest/framework/Formatter.scala
+++ b/js/shared/main/scala/utest/framework/Formatter.scala
@@ -60,8 +60,11 @@ class DefaultFormatter(color: Boolean = true,
   }
 
   def format(results: Tree[Result]): String = {
+    def errorFormatter(ex: Throwable): String =
+      s"Failure('$ex'${Option(ex.getCause).fold("")(cause => s" caused by '$cause'")})"
+
     results.map(r =>
-      r.name + "\t\t" + prettyTruncate(r, e => s"Failure ${e.getClass.getName}", r => (" " * r.name.length))
+      r.name + "\t\t" + prettyTruncate(r, errorFormatter, r => (" " * r.name.length))
     ).reduce(_ + _.map("\n" + _).mkString.replace("\n", "\n    "))
   }
 }


### PR DESCRIPTION
@lihaoyi  would you please merge this stuff? I'm asking you desperately again. [The old PR](https://github.com/lihaoyi/utest/pull/40) is deprecated, this one is actual. I'm unable to maintain the bug fix and feature over many scala.js versions and your changes to the same code. It's been more than 2 months Haoyi and it's like the fourth time I'm merging it to be able to use following scalajs version. It's really a total drag... I'm sick to my stomach every time I migrate to a new scala.js version because 90% of the time goes to utest because of this... I can't compile the utest RC1 version now due to : 
```
[info] Compiling 18 Scala sources to /home/lisak/Downloads/utest/js/target/scala-2.11/classes...
[error] /home/lisak/Downloads/utest/js/shared/main/scala/utest/package.scala:66: not found: value ScalaVersionStubs
[error]     @ScalaVersionStubs.compileTimeOnly("String#- method should only be used directly inside a TestSuite{} macro")
[error]      ^
[error] /home/lisak/Downloads/utest/js/shared/main/scala/utest/package.scala:75: not found: value ScalaVersionStubs
[error]     @ScalaVersionStubs.compileTimeOnly("String#- method should only be used directly inside a TestSuite{} macro")
[error]      ^
[error] /home/lisak/Downloads/utest/js/shared/main/scala/utest/package.scala:81: not found: value ScalaVersionStubs
[error]     @ScalaVersionStubs.compileTimeOnly("String#- method should only be used directly inside a TestSuite{} macro")
[error]      ^
```

