### PR TITLE
fix dependency logic to work in Scala 2.12 community build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,17 @@ import org.scalajs.core.tools.sem.CheckedBehavior
 
 crossScalaVersions := Seq("2.10.4", "2.11.4")
 
+def macroDependencies(version: String) =
+  ("org.scala-lang" % "scala-reflect" % version) +:
+  (if (version startsWith "2.10.")
+     Seq(compilerPlugin("org.scalamacros" % s"paradise" % "2.0.0" cross CrossVersion.full),
+         "org.scalamacros" %% s"quasiquotes" % "2.0.0")
+   else
+     Seq())
+
 lazy val utest = crossProject
   .settings(
-    libraryDependencies ++= Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
-    ) ++ (
-      if (scalaVersion.value startsWith "2.11.") Nil
-      else Seq(
-        compilerPlugin("org.scalamacros" % s"paradise" % "2.0.0" cross CrossVersion.full),
-        "org.scalamacros" %% s"quasiquotes" % "2.0.0"
-      )
-      ),
+    libraryDependencies ++= macroDependencies(scalaVersion.value),
     unmanagedSourceDirectories in Compile += {
       val v = if (scalaVersion.value startsWith "2.10.") "scala-2.10" else "scala-2.11"
       baseDirectory.value/".."/"shared"/"src"/"main"/v


### PR DESCRIPTION
the right logic is 2.10 vs the world, not 2.11 vs the world.

fwiw, I looked into whether I could add a 2.12 cross-build, but got
bogged down. the only Akka version that has been published for 2.12 is
2.4.0 for 2.12.0-M2, plus only certain Scala.js versions are available
for certain 2.12 milestone versions, so it got a bit complicated.