### PR TITLE
scala 2.12.0-M3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,11 @@ def macroDependencies(version: String) =
    else
      Seq())
 
+def akkaVersionFrom(scalaVersion: String): String = scalaVersion match {
+  case x if x.startsWith("2.10.") => "2.3.2" //scala 2.10 support
+  case _ => "2.4.2" //scala 2.11,2.12 support
+}
+
 lazy val utest = crossProject
   .settings(
     libraryDependencies ++= macroDependencies(scalaVersion.value),
@@ -60,12 +65,7 @@ lazy val utest = crossProject
     libraryDependencies ++= Seq(
       "org.scala-sbt" % "test-interface" % "1.0",
       "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
-      scalaVersion.value match {
-        case x if x.startsWith("2.10.") =>
-          "com.typesafe.akka" %% "akka-actor" % "2.3.2" % "test" //scala 2.10 support
-        case _ =>
-          "com.typesafe.akka" %% "akka-actor" % "2.4.2" % "test" //scala 2.11,2.12 support
-      }
+      "com.typesafe.akka" %% "akka-actor" % akkaVersionFrom(scalaVersion.value) % "test"
     ),
     resolvers += Resolver.sonatypeRepo("snapshots")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import org.scalajs.core.tools.sem.CheckedBehavior
 
-crossScalaVersions := Seq("2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.4", "2.11.4", "2.12.0-M3")
 
 def macroDependencies(version: String) =
   ("org.scala-lang" % "scala-reflect" % version) +:
@@ -13,14 +13,17 @@ def macroDependencies(version: String) =
 lazy val utest = crossProject
   .settings(
     libraryDependencies ++= macroDependencies(scalaVersion.value),
-    unmanagedSourceDirectories in Compile += {
-      val v = if (scalaVersion.value startsWith "2.10.") "scala-2.10" else "scala-2.11"
-      baseDirectory.value/".."/"shared"/"src"/"main"/v
-    },
+
     name := "utest",
     organization := "com.lihaoyi",
     version := "0.3.1",
     scalaVersion := "2.10.4",
+
+    scalacOptions ++= Seq(scalaVersion.value match {
+      case x if x.startsWith("2.12.") => "-target:jvm-1.8"
+      case x => "-target:jvm-1.6"
+    }),
+
     // Sonatype2
     publishArtifact in Test := false,
     publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
@@ -57,7 +60,12 @@ lazy val utest = crossProject
     libraryDependencies ++= Seq(
       "org.scala-sbt" % "test-interface" % "1.0",
       "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
-      "com.typesafe.akka" %% "akka-actor" % "2.3.2" % "test"
+      scalaVersion.value match {
+        case x if x.startsWith("2.10.") =>
+          "com.typesafe.akka" %% "akka-actor" % "2.3.2" % "test" //scala 2.10 support
+        case _ =>
+          "com.typesafe.akka" %% "akka-actor" % "2.4.2" % "test" //scala 2.11,2.12 support
+      }
     ),
     resolvers += Resolver.sonatypeRepo("snapshots")
   )

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.7")
 

--- a/utest/shared/src/main/scala-2.12.0-M3/utest/ScalaVersionStubs.scala
+++ b/utest/shared/src/main/scala-2.12.0-M3/utest/ScalaVersionStubs.scala
@@ -1,0 +1,6 @@
+package utest
+
+
+object ScalaVersionStubs {
+  type compileTimeOnly = scala.annotation.compileTimeOnly
+}


### PR DESCRIPTION
adding support for 2.12.0-M3. Per the scala versioning rules, milestone versions are their own API compatibility and do not represent '2.12', so support will need to be added for additional milestones (~~can be updated in code review or done later~~)  pending new scala-js releases for milestones.

I removed the 'unmanagedSourceDirectories' setting from sbt because ~~by some black magic SBT was already looking there (and was giving me 'class already defined' issues)~~ of the 0.6.7 upgrade. again given versioning rules, the milestones are their own major version and the folder was named as such.

scala-js version was upgraded to 0.6.7, giving the same API compatibility, just updated version and with 2.12 support. 

anybody looking for this support ASAP can use my repo (with utest version 0.3.1):

```scala
//temporary resolver for colinrgodsey fork of utest@0.3.1 for 2.12.0-M3 support
resolvers += "mvn repo" at "https://raw.githubusercontent.com/colinrgodsey/maven/master"
libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1" % "test"
```