### PR TITLE
avoid deprecated getStackTraceString method

### DIFF
--- a/utest/shared/src/main/scala/utest/framework/ExecutionContext.scala
+++ b/utest/shared/src/main/scala/utest/framework/ExecutionContext.scala
@@ -21,7 +21,7 @@ object ExecutionContext{
 
     def reportFailure(t: Throwable) = {
       Console.err.println("Failure in RunNow async execution: " + t)
-      Console.err.println(t.getStackTraceString)
+      Console.err.println(t.getStackTrace.mkString("\n"))
     }
   }
 }


### PR DESCRIPTION
it has been removed from Scala 2.13

this will make utest work again in the Scala 2.13 community build