### PR TITLE
[WIP] Change presentation of test results

### DIFF
--- a/utest/shared/src/main/scala/utest/asserts/Asserts.scala
+++ b/utest/shared/src/main/scala/utest/asserts/Asserts.scala
@@ -105,7 +105,7 @@ object Asserts {
     failures match{
       case Seq() => () // nothing failed, do nothing
       case Seq(failure) => throw failure
-      case multipleFailures => throw new MultipleErrors(multipleFailures:_*)
+      case multipleFailures => throw MultipleErrors(multipleFailures:_*)
     }
   }
 

--- a/utest/shared/src/main/scala/utest/asserts/package.scala
+++ b/utest/shared/src/main/scala/utest/asserts/package.scala
@@ -16,15 +16,18 @@ package object asserts extends utest.asserts.Asserts[DummyTypeclass]{
 
   type AssertEntry[T] = (String, (TestValue => Unit) => T)
 
+  def renderTestValue(testValue: TestValue) = {
+    val TestValue(name, tpe, value) = testValue
+    s"${name.magenta}: ${tpe.toString.yellow} = ${value.toString.blue}"
+  }
+
   /**
    * Shorthand to quickly throw a utest.AssertionError, together with all the
    * macro-debugging goodness
    */
   def assertError(msgPrefix: String, logged: Seq[TestValue], cause: Throwable = null) = {
     throw AssertionError(
-      msgPrefix + Option(cause).fold("")(e => s"\ncaused by: ${e.toString.red}") + logged.map{
-        case TestValue(name, tpe, thing) => s"\n${name.magenta}: ${tpe.toString.yellow} = ${thing.toString.blue}"
-      }.mkString,
+      msgPrefix + Option(cause).fold("")(e => s"\ncaused by: ${e.toString.red}") + logged.map(v => "\n" + renderTestValue(v)).mkString,
       logged,
       cause
     )

--- a/utest/shared/src/main/scala/utest/asserts/package.scala
+++ b/utest/shared/src/main/scala/utest/asserts/package.scala
@@ -23,7 +23,7 @@ package object asserts extends utest.asserts.Asserts[DummyTypeclass]{
   def assertError(msgPrefix: String, logged: Seq[TestValue], cause: Throwable = null) = {
     throw AssertionError(
       msgPrefix + Option(cause).fold("")(e => s"\ncaused by: ${e.toString.red}") + logged.map{
-        case TestValue(name, tpe, thing) => s"\n${name.blue}: ${tpe.toString.yellow} = ${thing.toString}"
+        case TestValue(name, tpe, thing) => s"\n${name.magenta}: ${tpe.toString.yellow} = ${thing.toString.blue}"
       }.mkString,
       logged,
       cause

--- a/utest/shared/src/main/scala/utest/asserts/package.scala
+++ b/utest/shared/src/main/scala/utest/asserts/package.scala
@@ -22,8 +22,8 @@ package object asserts extends utest.asserts.Asserts[DummyTypeclass]{
    */
   def assertError(msgPrefix: String, logged: Seq[TestValue], cause: Throwable = null) = {
     throw AssertionError(
-      msgPrefix + Option(cause).fold("")(e => s"\ncaused by: $e") + logged.map{
-        case TestValue(name, tpe, thing) => s"\n$name: $tpe = $thing"
+      msgPrefix + Option(cause).fold("")(e => s"\ncaused by: ${e.toString.red}") + logged.map{
+        case TestValue(name, tpe, thing) => s"\n${name.blue}: ${tpe.toString.yellow} = ${thing.toString}"
       }.mkString,
       logged,
       cause

--- a/utest/shared/src/main/scala/utest/framework/Formatter.scala
+++ b/utest/shared/src/main/scala/utest/framework/Formatter.scala
@@ -25,7 +25,7 @@ trait Formatter {
                                    offset: Result => String = _ => ""): String = {
 
 
-    val durationStr = s"${Console.RESET + (r.milliDuration.toString + " ms").faint}"
+    val durationStr = Console.RESET + (r.milliDuration.toString + " ms").faint
     val cutUnit = r.value match {
       case Success(()) => durationStr
       case Success(v: Any) =>
@@ -41,6 +41,8 @@ trait Formatter {
     if (formatColor) formatStartColor(success = r.value.isSuccess) + truncUnit + formatEndColor else truncUnit
   }
 
+  private val successIcon = "\u25C9".green
+  private val failureIcon = "\u25C9".red
   def format(results: Tree[Result]): Option[String] = Some {
     def errorFormatter(ex: Throwable): String = {
       val causation = Option(ex.getCause) match {
@@ -52,16 +54,13 @@ trait Formatter {
       ex.toString.bold.white.redBg + "\n" + causation
     }
 
-    val greenCircle = "\u25C9".green
-    val redCircle = "\u25C9".red
     results.map(result => {
-      val failed = result.value.isFailure
-      val icon = if (failed) redCircle else greenCircle
+      val isFailure = result.value.isFailure
+      val icon = if (isFailure) failureIcon else successIcon
       val nameSegment = " " + result.name + " "
-      val ttt = if (failed) nameSegment.bold.white.redBg else nameSegment.bold
-      icon + ttt + prettyTruncate(result, errorFormatter, r => "  ")
+      val testNameText = if (isFailure) nameSegment.bold.white.redBg else nameSegment.bold
+      icon + testNameText + prettyTruncate(result, errorFormatter, r => "  ")
     }
     ).reduce(_ + _.map("\n" + _).mkString.replace("\n", "\n  "))
   }
 }
-

--- a/utest/shared/src/main/scala/utest/framework/Formatter.scala
+++ b/utest/shared/src/main/scala/utest/framework/Formatter.scala
@@ -51,7 +51,14 @@ trait Formatter {
         case None =>
            ""
       }
-      ex.toString.bold.white.redBg + "\n" + causation
+
+      val errStr = ex.toString
+      val assertPrefix = "utest.AssertionError:"
+      if (errStr.startsWith(assertPrefix)) {
+        assertPrefix.bold.white.redBg + errStr.stripPrefix(assertPrefix)
+      } else {
+        errStr.bold.white.redBg + "\n" + causation
+      }
     }
 
     results.map(result => {

--- a/utest/shared/src/main/scala/utest/framework/Model.scala
+++ b/utest/shared/src/main/scala/utest/framework/Model.scala
@@ -13,21 +13,22 @@ import scala.concurrent.Future
 import utest.PlatformShims
 
 case class TestPath(value: Seq[String])
-object TestPath{
+object TestPath {
   @reflect.internal.annotations.compileTimeOnly(
     "TestPath is only available within a uTest suite, and not outside."
   )
   implicit def synthetic: TestPath = ???
 }
-object Test{
+
+object Test {
   /**
-   * Creates a test from a set of children, a name a a [[TestThunKTree]].
+   * Creates a test from a set of children, a name a a [[TestThunkTree]].
    * Generally called by the [[TestSuite.apply]] macro and doesn't need to
    * be called manually.
    */
   def create(tests: (String, (String, TestThunkTree) => Tree[Test])*)
             (name: String, testTree: TestThunkTree): Tree[Test] = {
-    new Tree(
+    Tree(
       new Test(name, testTree),
       tests.map{ case (k, v) => v(k, testTree) }
     )

--- a/utest/shared/src/main/scala/utest/package.scala
+++ b/utest/shared/src/main/scala/utest/package.scala
@@ -8,8 +8,8 @@ import scala.concurrent.duration._
  * Created by haoyi on 1/24/14.
  */
 package object utest {
-  implicit val retryInterval = new RetryInterval(100.millis)
-  implicit val retryMax = new RetryMax(1.second)
+  implicit val retryInterval = RetryInterval(100.millis)
+  implicit val retryMax = RetryMax(1.second)
   import scala.language.experimental.macros
 
   implicit class ColorStrings(s: String) {
@@ -17,8 +17,11 @@ package object utest {
     def blue = wrap(Console.BLUE)
     def green = wrap(Console.GREEN)
     def red = wrap(Console.RED)
+    def redBg = wrap(Console.RED_B)
     def bold = wrap(Console.BOLD)
     def yellow = wrap(Console.YELLOW)
+    def white = wrap(Console.WHITE)
+    def magenta = wrap(Console.MAGENTA)
     def faint = wrap("\u001b[2m")
   }
 
@@ -57,7 +60,7 @@ package object utest {
    * Extension methods on `Tree[Test]` in order to conveniently run the tests
    * and aggregate the results
    */
-  implicit def toTestSeq(t: Tree[Test]) = new TestTreeSeq(t)
+  implicit def toTestSeq(t: Tree[Test]): TestTreeSeq = new TestTreeSeq(t)
 
 
   /**

--- a/utest/shared/src/main/scala/utest/package.scala
+++ b/utest/shared/src/main/scala/utest/package.scala
@@ -12,6 +12,16 @@ package object utest {
   implicit val retryMax = new RetryMax(1.second)
   import scala.language.experimental.macros
 
+  implicit class ColorStrings(s: String) {
+    private def wrap(ansiColorSequence: String) = ansiColorSequence + s + Console.RESET
+    def blue = wrap(Console.BLUE)
+    def green = wrap(Console.GREEN)
+    def red = wrap(Console.RED)
+    def bold = wrap(Console.BOLD)
+    def yellow = wrap(Console.YELLOW)
+    def faint = wrap("\u001b[2m")
+  }
+
   type Show = asserts.Show
   /**
    * Extension methods to allow you to create tests via the "omg"-{ ... }

--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -1,9 +1,10 @@
 package utest
 package runner
 //import acyclic.file
+import scala.concurrent.ExecutionContext
+
 import sbt.testing._
 import utest.TestSuite
-
 import scala.util.Failure
 
 import org.scalajs.testinterface.TestUtils
@@ -57,7 +58,7 @@ abstract class BaseRunner(val args: Array[String],
 
     addTotal(found.length)
 
-    implicit val ec =
+    implicit val ec: ExecutionContext =
       if (utest.framework.ArgParse.find("--parallel", _.toBoolean, false, true)(args)){
         scala.concurrent.ExecutionContext.global
       }else{

--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -68,9 +68,7 @@ abstract class BaseRunner(val args: Array[String],
       (subpath, s) => {
         if(s.value.isSuccess) incSuccess() else  incFailure()
 
-        val str = suite.formatSingle(selector ++ subpath, s)
         handleEvent(new OptionalThrowable(), Status.Success)
-        str.foreach{msg => loggers.foreach(_.info(name + "" + msg))}
         s.value match{
           case Failure(e) =>
             handleEvent(new OptionalThrowable(e), Status.Failure)
@@ -79,7 +77,7 @@ abstract class BaseRunner(val args: Array[String],
             e.setStackTrace(
               e.getStackTrace.takeWhile(_.getClassName != "utest.framework.TestThunkTree")
             )
-            addFailure(name + "" + str.getOrElse(""))
+            addFailure(name)
             addTrace(
               if (e.isInstanceOf[SkippedOuterFailure]) ""
               else e.getStackTrace.map(_.toString).mkString("\n")

--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -69,7 +69,7 @@ abstract class BaseRunner(val args: Array[String],
         if(s.value.isSuccess) incSuccess() else  incFailure()
 
         handleEvent(new OptionalThrowable(), Status.Success)
-        s.value match{
+        s.value match {
           case Failure(e) =>
             handleEvent(new OptionalThrowable(e), Status.Failure)
             // Trim the stack trace so all the utest internals don't get shown,

--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -49,7 +49,7 @@ abstract class BaseRunner(val args: Array[String],
       })
     }
 
-    val title = s"Starting Suite " + name
+    val title = s"Starting Suite " + name.bold.red
     val dashes = "-" * ((80 - title.length) / 2)
     loggers.foreach(_.info(dashes + title + dashes))
 

--- a/utest/shared/src/main/scala/utest/runner/MasterRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/MasterRunner.scala
@@ -26,11 +26,11 @@ final class MasterRunner(args: Array[String],
     if (!results.compareAndSet(old, r :: old)) addResult(r)
   }
 
-  @tailrec final def addFailure(r: String): Unit = {
+  @tailrec def addFailure(r: String): Unit = {
     val old = failures.get()
     if (!failures.compareAndSet(old, r :: old)) addFailure(r)
   }
-  @tailrec final def addTrace(r: String): Unit = {
+  @tailrec def addTrace(r: String): Unit = {
     val old = traces.get()
     if (!traces.compareAndSet(old, r :: old)) addTrace(r)
   }
@@ -49,25 +49,25 @@ final class MasterRunner(args: Array[String],
 
     val body = results.get.mkString("\n")
 
-    val failureMsg = if (failures.get() == Nil) ""
-    else Seq(
-      Console.RED + "Failures:",
-      failures.get()
-              .zip(traces.get())
-              // We pre-pending to a list, so need to reverse to make the order correct
-              .reverse
-              // ignore those with an empty trace, e.g. utest.SkippedOuterFailures,
-              // since those are generally just spam (we already can see the outer failure)
-              .collect{case (f, t) if t != "" => f + ("\n" + t).replace("\n", "\n"+Console.RED)}
-              .mkString("\n")
-    ).mkString("\n")
+    val failureMsg = "" // if (failures.get() == Nil) ""
+//    else Seq(
+//      Console.RED + "Failures:",
+//      failures.get()
+//              .zip(traces.get())
+//              // We pre-pending to a list, so need to reverse to make the order correct
+//              .reverse
+//              // ignore those with an empty trace, e.g. utest.SkippedOuterFailures,
+//              // since those are generally just spam (we already can see the outer failure)
+//              .collect{case (f, t) if t != "" => f + ("\n" + t).replace("\n", "\n"+Console.RED)}
+//              .mkString("\n")
+//    ).mkString("\n")
     Seq(
       header,
       body,
       failureMsg,
-      s"Tests: $total",
-      s"Passed: $success",
-      s"Failed: $failure"
+      s"Tests: ".bold + totalCount.toString.blue,
+      s"Passed: ".bold + successCount.toString.blue,
+      s"Failed: ".bold + (if (failureCount == 0) failureCount.toString.bold.green else s" $failureCount ".redBg.bold.white)
     ).mkString("\n")
   }
 

--- a/utest/shared/src/main/scala/utest/runner/MasterRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/MasterRunner.scala
@@ -67,7 +67,7 @@ final class MasterRunner(args: Array[String],
       failureMsg,
       s"Tests: ".bold + totalCount.toString.blue,
       s"Passed: ".bold + successCount.toString.blue,
-      s"Failed: ".bold + (if (failureCount == 0) failureCount.toString.bold.green else s" $failureCount ".redBg.bold.white)
+      s"Failed: ".bold + (if (failureCount == 0) failureCount.toString.green else s" $failureCount ".redBg.bold.white)
     ).mkString("\n")
   }
 

--- a/utest/shared/src/test/scala/test/utest/AssertsTests.scala
+++ b/utest/shared/src/test/scala/test/utest/AssertsTests.scala
@@ -42,9 +42,11 @@ object AssertsTests extends utest.TestSuite{
           "Logging didn't capture the locals properly " + logged
         )
 
-        * - Predef.assert(
-          e.toString.contains("y: String = 2") && e.toString.contains("x: Int = 1"),
-          "Logging doesn't display local values properly " + e.toString
+        val errStr = e.toString
+        val yRendered = asserts.renderTestValue(TestValue("y", "String", 2))
+        val xRendered = asserts.renderTestValue(TestValue("x", "Int", 1))
+        "Logging doesn't display local values properly" - assert(
+          errStr.contains(yRendered) && e.toString.contains(xRendered)
         )
 
         * - Predef.assert(

--- a/utest/shared/src/test/scala/test/utest/DisablePrint2Tests.scala
+++ b/utest/shared/src/test/scala/test/utest/DisablePrint2Tests.scala
@@ -2,7 +2,6 @@ package test.utest
 import utest._
 
 object DisablePrint2Tests extends utest.TestSuite{
-  override def formatSingle(path: Seq[String], res: utest.framework.Result) = None
   override def formatColor = false
   def tests = this{
     'hello{


### PR DESCRIPTION
I've tried to work on the presentation of the test results to increase readability and also (hopefully) look a little prettier. It's still pretty work-in-progress both the presentation and the code, but I hope it's a step in the right direction..(?)

Some feedback would be nice. Is it better or worse? Is it too much color, or should I try to colorize/syntax-highlight more?

One controversial/debetable change I've made is that I've skipped the first test-printing phase. Where as before the output was printed "twice" (first when it actually runs, and then a second time with the "results" of the test running). Personally I strongly prefer to just get the summary (like now), but if anyone has a different opinion, I'm open for changing it back. Perhaps make it configurable somehow?

Before:
<img width="895" alt="screen shot 2017-05-07 at 15 48 49" src="https://cloud.githubusercontent.com/assets/4758115/25781687/08f20678-333d-11e7-87fa-dc0559658dc2.png">

After:
<img width="814" alt="screen shot 2017-05-07 at 15 47 32" src="https://cloud.githubusercontent.com/assets/4758115/25781689/15d49d2e-333d-11e7-833b-c20fdcf3f3e2.png">
