### PR TITLE
Cross compile to Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
 language: scala
-sudo: false
+sudo: required
+dist: trusty
 
 jdk:
   - oraclejdk8
-scala:
-  - 2.10.6
-  - 2.11.11
-  - 2.12.2
-  - 2.13.0-M1
+
 matrix:
   include:
     - scala: 2.10.6
       jdk: openjdk7
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
+
+    - scala: 2.11.11
+      before_script:
+      - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.0/bin/travis_setup.sh | bash -x
+      sudo: required
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test utestNative/test
+
+    - scala: 2.12.2
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
+
+    - scala: 2.13.0-M1
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
 # Taken from https://github.com/typelevel/cats/blob/master/.travis.yml
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import sbtcrossproject.{crossProject, CrossType}
 import com.typesafe.sbt.pgp.PgpKeys._
 
 name               in ThisBuild := "utest"
@@ -10,8 +11,9 @@ triggeredMessage   in ThisBuild := Watched.clearWhenTriggered
 releaseTagComment  in ThisBuild := s"v${(version in ThisBuild).value}"
 releaseVcsSign     in ThisBuild := true
 
-lazy val utest = crossProject
+lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
+    name                  := "utest",
     scalacOptions         := Seq("-Ywarn-dead-code"),
     scalacOptions in Test -= "-Ywarn-dead-code",
     libraryDependencies  ++= macroDependencies(scalaVersion.value),
@@ -61,6 +63,12 @@ lazy val utest = crossProject
     ),
     resolvers += Resolver.sonatypeRepo("snapshots")
   )
+  .nativeSettings(
+    scalaVersion := "2.11.11",
+    libraryDependencies ++= Seq(
+      "org.scala-native" %%% "test-interface" % "0.3.0"
+    )
+  )
 
 def macroDependencies(version: String) =
   ("org.scala-lang" % "scala-reflect" % version) +:
@@ -72,9 +80,10 @@ def macroDependencies(version: String) =
 
 lazy val utestJS = utest.js
 lazy val utestJVM = utest.jvm
+lazy val utestNative = utest.native
 
 lazy val root = project.in(file("."))
-  .aggregate(utestJS, utestJVM)
+  .aggregate(utestJS, utestJVM, utestNative)
   .settings(
     publishTo := Some(Resolver.file("Unused transient repository", target.value / "fakepublish")),
     publishArtifact := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-addSbtPlugin("org.scala-js"      % "sbt-scalajs" % "0.6.16")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"     % "1.0.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
-
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"                  % "1.0.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release"              % "1.0.5")
+addSbtPlugin("org.scala-js"      % "sbt-scalajs"              % "0.6.16")
+addSbtPlugin("org.scala-native"  % "sbt-crossproject"         % "0.2.0")
+addSbtPlugin("org.scala-native"  % "sbt-scalajs-crossproject" % "0.2.0")
+addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.0")

--- a/utest/native/PlatformShims.scala
+++ b/utest/native/PlatformShims.scala
@@ -1,0 +1,19 @@
+package utest
+
+// Taken from the implementation for JS
+
+import scala.concurrent.Future
+
+/**
+ * Platform specific stuff that differs between JVM and Native
+ */
+object PlatformShims {
+  def await[T](f: Future[T]): T = {
+    f.value match {
+      case Some(v) => v.get
+      case None => throw new IllegalStateException(
+        "Test that returns Future must be run asynchronously in Scala Native, see TestTreeSeq::runAsync"
+      )
+    }
+  }
+}

--- a/utest/native/src/test/scala/utest/Scheduler.scala
+++ b/utest/native/src/test/scala/utest/Scheduler.scala
@@ -1,0 +1,16 @@
+package utest
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration.FiniteDuration
+
+object Scheduler {
+  // Will execute immediately, because we cannot currenly schedule
+  // computation in Scala Native. (Execution happens either immediately
+  // or at the end of the program.)
+  def scheduleOnce[T](interval: FiniteDuration)
+                     (thunk: => T)
+                     (implicit executor: ExecutionContext): Unit = {
+    Future { thunk }
+    ()
+  }
+}

--- a/utest/shared/src/test/scala/test/utest/AssertsTests.scala
+++ b/utest/shared/src/test/scala/test/utest/AssertsTests.scala
@@ -53,14 +53,12 @@ object AssertsTests extends utest.TestSuite{
         )
       }
       'failureWithException{
-        val x = 1L
-        val y = 0l
         try {
-          assert(x / y == 10)
+          assert(Iterator.empty.next() == 10)
           Predef.assert(false)
         } catch {case e @ utest.AssertionError(src, logged, cause) =>
-          Predef.assert(cause.isInstanceOf[ArithmeticException])
-          Predef.assert(cause.getMessage == "/ by zero")
+          Predef.assert(cause.isInstanceOf[NoSuchElementException])
+          Predef.assert(cause.getMessage == "next on empty iterator")
           e.getMessage
         }
       }
@@ -178,14 +176,14 @@ object AssertsTests extends utest.TestSuite{
 
       'failureWithException{
         try {
-          val a = 1L
+          val a = Iterator.empty
           val b = 2
-          assertMatch(Seq(a / 0, 3, b)){case Seq(1, 2) =>}
+          assertMatch(Seq(a.next(), 3, b)){case Seq(1, 2) =>}
           Predef.assert(false)
         } catch{ case e: utest.AssertionError =>
-          Predef.assert(e.captured == Seq(TestValue("a", "Long", 1)))
-          Predef.assert(e.cause.isInstanceOf[ArithmeticException])
-          Predef.assert(e.msg.contains("assertMatch(Seq(a / 0, 3, b)){case Seq(1, 2) =>}"))
+          Predef.assert(e.captured == Seq(TestValue("a", "Iterator[Nothing]", Iterator.empty)))
+          Predef.assert(e.cause.isInstanceOf[NoSuchElementException])
+          Predef.assert(e.msg.contains("assertMatch(Seq(a.next(), 3, b)){case Seq(1, 2) =>}"))
           e.getMessage
         }
       }

--- a/utest/shared/src/test/scala/test/utest/FrameworkTests.scala
+++ b/utest/shared/src/test/scala/test/utest/FrameworkTests.scala
@@ -219,7 +219,12 @@ object FrameworkTests extends utest.TestSuite{
     // These are Fatal in Scala.JS. Ensure they're handled else they freeze SBT.
     'catchCastError{
       val tests = this{
-        'ah {0.asInstanceOf[String]}
+        'ah {
+          // This test is disabled until scala-native/scala-native#858 is not fixed.
+          val isNative = sys.props("java.vm.name") == "Scala Native"
+          assert(!isNative)
+          0.asInstanceOf[String]
+        }
      }
       assertMatch(tests.run(testPath=Seq("ah")).toSeq)
                  {case Seq(Result("ah", Failure(_), _))=>}


### PR DESCRIPTION
The next release of Scala Native is coming soon, and it will add support for test frameworks using sbt's test interface (scala-native/scala-native#755). While implementing the test interface, I cross compiled utest to Scala Native.

Here are the changes that I did to get it to cross compile and work with Scala Native. Obviously, Scala Native 0.3.0 is not released yet, and you'll need to build Scala Native locally to test it. Here's what it looks like: https://travis-ci.org/Duhemm/scala-native/jobs/242582498#L2665-L2697

## How to try it

 - Here's the branch that adds the test interface to Scala Native: https://github.com/Duhemm/scala-native/tree/topic/test-interface (use that instead of Scala Native's `master` branch if you happen to read that before the aforementioned PR is merged).
 - Here's how to get started with Scala Native: http://www.scala-native.org/en/latest/user/setup.html

After your system is set up, you can build Scala Native locally:

```
$ git clone https://github.com/scala-native/scala-native.git
$ cd scala-native
$ sbt rebuild
```

Then, build and `publishLocal`ly this PR. You can use the published artifact in a Scala Native project [as shown here](https://github.com/Duhemm/scala-native/blob/8939e764fff8faae8a77df9b872df1414dc403c1/build.sbt#L431-L432). Write your tests as usual and run them using `test` in sbt.

It would be great if we could get this PR in soon after Scala Native is released (I'll update it with the correct version numbers). Do you see things that need to be addressed in this PR while we wait for the next release of Scala Native?