### PR TITLE
Only cross-build native project to 2.11.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(
     scalaVersion := "2.11.11",
+    crossScalaVersions := Seq("2.11.11"),
     libraryDependencies ++= Seq(
       "org.scala-native" %%% "test-interface" % "0.3.0"
     )


### PR DESCRIPTION
I got resolution errors for native on 2.10 when running `+test`. With this change, it's possible to use [sbt-doge](https://github.com/sbt/sbt-doge) to test/publish in all cross-versions for all projects with `very publish/very test`