### PR TITLE
Publish 0.4.8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ you can immediately begin defining and running tests programmatically.
 
 
 ```scala
-libraryDependencies += "com.lihaoyi" %% "utest" % "0.4.7" % "test"
+libraryDependencies += "com.lihaoyi" %% "utest" % "0.4.8" % "test"
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 ```
@@ -62,7 +62,7 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 To use it with Scala.js, swap out the `libraryDependencies` with
 
 ```scala
-libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.7" % "test"
+libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.8" % "test"
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 ```
@@ -926,6 +926,11 @@ To publish use
 
 Changelog
 =========
+
+0.4.8
+-----
+
+- Scala Native support.
 
 0.4.7
 -----

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.8"
+version in ThisBuild := "0.4.9-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.8-SNAPSHOT"
+version in ThisBuild := "0.4.8"


### PR DESCRIPTION
I've never used sbt-release before. I ran `release` but it didn't respect `crossScalaVersions` so I manually `; ++2.X publishSigned` for js and jvm on 2.10/2.11/2.13. All artifacts seem to be in place https://oss.sonatype.org/content/repositories/releases/com/lihaoyi/ It would be nice to boil the release step into a single command in the future.