### PR TITLE
adds support for before/after each

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -967,7 +967,8 @@ This is a flexible function that wraps every test call; you can use it to:
   e.g. `Seq("outer", "inner1", "innerest")` for the test `outer.inner1.innerest`
 
 Generally, if you want to perform messy before/after logic around every
-individual test, override `utestWrap`.
+individual test, override `utestWrap`. Please remember to call the
+`utestBeforeEach` and `utestAfterEach` methods when needed.
 
 `runBody` is a future to support asynchronous testing, which is the only way to
 test things like Ajax calls in [Scala.js](#scalajs-and-scala-native)
@@ -1120,7 +1121,10 @@ val results3 = TestRunner.runAndPrint(
     override def utestWrap(path: Seq[String], runBody: => Future[Any])
                  (implicit ec: ExecutionContext): Future[Any] = {
       println("Getting ready to run " + path.mkString("."))
-      runBody
+      utestBeforeEach()
+      runBody.andThen {
+        case _ => utestAfterEach()
+      }
     }
   },
   formatter = new utest.framework.Formatter{

--- a/utest/shared/src/main/scala/utest/TestSuite.scala
+++ b/utest/shared/src/main/scala/utest/TestSuite.scala
@@ -29,12 +29,12 @@ object TestSuite {
     val utestRetryCount: Int
     override def utestWrap(path: Seq[String], body: => Future[Any])(implicit ec: ExecutionContext): Future[Any] = {
       def rec(count: Int): Future[Any] = {
-        beforeEach
+        utestBeforeEach()
         body.recoverWith { case e =>
           if (count < 5) rec(count + 1)
           else throw e
         }.andThen {
-          case _ => afterEach
+          case _ => utestAfterEach()
         }
       }
       val res = rec(0)

--- a/utest/shared/src/main/scala/utest/TestSuite.scala
+++ b/utest/shared/src/main/scala/utest/TestSuite.scala
@@ -29,9 +29,12 @@ object TestSuite {
     val utestRetryCount: Int
     override def utestWrap(path: Seq[String], body: => Future[Any])(implicit ec: ExecutionContext): Future[Any] = {
       def rec(count: Int): Future[Any] = {
+        beforeEach
         body.recoverWith { case e =>
           if (count < 5) rec(count + 1)
           else throw e
+        }.andThen {
+          case _ => afterEach
         }
       }
       val res = rec(0)

--- a/utest/shared/src/main/scala/utest/framework/Executor.scala
+++ b/utest/shared/src/main/scala/utest/framework/Executor.scala
@@ -1,10 +1,16 @@
 package utest.framework
 
 object Executor extends Executor
-trait Executor extends Formatter{
+trait Executor extends Formatter {
+  def beforeEach: Unit = ()
+  def afterEach: Unit = ()
+
   def utestWrap(path: Seq[String], runBody: => concurrent.Future[Any])
                (implicit ec: concurrent.ExecutionContext): concurrent.Future[Any] = {
-    runBody
-  }
+    beforeEach
 
+    runBody.andThen {
+      case _ => afterEach
+    }
+  }
 }

--- a/utest/shared/src/main/scala/utest/framework/Executor.scala
+++ b/utest/shared/src/main/scala/utest/framework/Executor.scala
@@ -2,15 +2,15 @@ package utest.framework
 
 object Executor extends Executor
 trait Executor extends Formatter {
-  def beforeEach: Unit = ()
-  def afterEach: Unit = ()
+  def utestBeforeEach(): Unit = ()
+  def utestAfterEach(): Unit = ()
 
   def utestWrap(path: Seq[String], runBody: => concurrent.Future[Any])
                (implicit ec: concurrent.ExecutionContext): concurrent.Future[Any] = {
-    beforeEach
+    utestBeforeEach()
 
     runBody.andThen {
-      case _ => afterEach
+      case _ => utestAfterEach()
     }
   }
 }

--- a/utest/shared/src/test/scala/test/utest/FrameworkTests.scala
+++ b/utest/shared/src/test/scala/test/utest/FrameworkTests.scala
@@ -10,15 +10,13 @@ import scala.util.Failure
 
 
 object FrameworkTests extends utest.TestSuite{
-  override def utestWrap(path: Seq[String], runBody: => concurrent.Future[Any])
-                        (implicit ec: ExecutionContext): concurrent.Future[Any] = {
-    println("RUN " + path.mkString("."))
-
-    runBody.map{x =>
-      println("END " + path.mkString("."))
-      x
-    }
+  override def beforeEach = {
+    println("RUN")
   }
+  override def afterEach = {
+    println("END")
+  }
+
   implicit val ec = utest.framework.ExecutionContext.RunNow
   def tests = Tests{
     def testHelloWorld(tests: Tests) = {

--- a/utest/shared/src/test/scala/test/utest/FrameworkTests.scala
+++ b/utest/shared/src/test/scala/test/utest/FrameworkTests.scala
@@ -10,13 +10,22 @@ import scala.util.Failure
 
 
 object FrameworkTests extends utest.TestSuite{
-  override def beforeEach = {
-    println("RUN")
+  override def utestBeforeEach() = {
+    println("RUN before each")
   }
-  override def afterEach = {
-    println("END")
+  override def utestAfterEach() = {
+    println("END after each")
   }
 
+  override def utestWrap(path: Seq[String], runBody: => concurrent.Future[Any])
+                        (implicit ec: ExecutionContext): concurrent.Future[Any] = {
+    println("RUN " + path.mkString("."))
+
+    runBody.map{x =>
+      println("END " + path.mkString("."))
+      x
+    }
+  }
   implicit val ec = utest.framework.ExecutionContext.RunNow
   def tests = Tests{
     def testHelloWorld(tests: Tests) = {

--- a/utest/shared/src/test/scala/test/utest/RetryTests.scala
+++ b/utest/shared/src/test/scala/test/utest/RetryTests.scala
@@ -66,3 +66,32 @@ object LocalRetryTests extends utest.TestSuite{
   }
 }
 
+// TODO: bug with retry assert
+// object LocalRetryBeforeEachTests extends utest.TestSuite{
+//   var x = 0
+//   override def utestBeforeEach() = {
+//     println(s">>> before each x: $x")
+//     x = 0
+//   }
+//   val flaky = new FlakyThing
+
+//   def tests = Tests{
+//     'hello - retry(3){
+//       println(s">>> x: $x")
+//       assert(x == 0)
+//       x += 1
+//       flaky.run
+//     }
+//   }
+// }
+
+// -------------------------------- Running Tests --------------------------------
+//   Setting up CustomFramework
+//   >>> before each x: 0
+//   >>> x: 0
+//   >>> x: 1
+//   >>> x: 1
+//   >>> x: 1
+// X test.utest.LocalRetryBeforeEachTests.hello 20ms
+// utest.AssertionError: assert(x == 0)
+// utest.asserts.Asserts$.assertImpl(Asserts.scala:114)

--- a/utest/shared/src/test/scala/test/utest/examples/BeforeAfterEachTests.scala
+++ b/utest/shared/src/test/scala/test/utest/examples/BeforeAfterEachTests.scala
@@ -1,0 +1,29 @@
+package test.utest.examples
+
+import utest._
+object BeforeAfterEachTest extends TestSuite{
+  var x = 0
+  override def beforeEach = {
+    println(s"x before: $x")
+    x = 0
+  }
+  override def afterEach = {
+    println(s"x after: $x")
+  }
+
+  val tests = Tests{
+    'test1{
+      x += 1
+      assert(x == 1)
+    }
+    'test2{
+      'inner{
+        assert(x == 0)
+      }
+    }
+    'test3{
+      x += 42
+      assert(x == 42)
+    }
+  }
+}

--- a/utest/shared/src/test/scala/test/utest/examples/BeforeAfterEachTests.scala
+++ b/utest/shared/src/test/scala/test/utest/examples/BeforeAfterEachTests.scala
@@ -1,29 +1,36 @@
 package test.utest.examples
 
 import utest._
-object BeforeAfterEachTest extends TestSuite{
+object BeforeAfterEachTest extends TestSuite {
   var x = 0
-  override def beforeEach = {
-    println(s"x before: $x")
+  override def utestBeforeEach() = {
+    println(s"on before each x: $x")
     x = 0
   }
-  override def afterEach = {
-    println(s"x after: $x")
-  }
+  override def utestAfterEach() =
+    println(s"on after each x: $x")
 
   val tests = Tests{
-    'test1{
+    'outer1 - {
       x += 1
-      assert(x == 1)
-    }
-    'test2{
-      'inner{
-        assert(x == 0)
+      'inner1 - {
+        x += 2
+        assert(x == 3) // += 1, += 2
+        x
+      }
+      'inner2 - {
+        x += 3
+        assert(x == 4) // += 1, += 3
+        x
       }
     }
-    'test3{
-      x += 42
-      assert(x == 42)
+    'outer2 - {
+      x += 4
+      'inner3 - {
+        x += 5
+        assert(x == 9) // += 4, += 5
+        x
+      }
     }
   }
 }


### PR DESCRIPTION
I wanted to check with you @lihaoyi before continue adding support to this.
This adds support for before/after each.

I'm just wondering if you would like to have the methods returning a `Unit` or a `Future[Unit]`, current approach is similar to scalatest.

also I wasn't sure to add the path parameters to the current methods, as this methods seems to be more agnostic about what test is being called.

Just let me know what do you think.

```
-------------------------------- Running Tests --------------------------------
Setting up CustomFramework
x before: 0
x after: 1
+ test.utest.examples.BeforeAfterEachTest.test1 46ms  
x before: 1
x after: 0
+ test.utest.examples.BeforeAfterEachTest.test2.inner 1ms  
x before: 0
x after: 42
+ test.utest.examples.BeforeAfterEachTest.test3 0ms  
Tearing down CustomFramework
```