### PR TITLE
Ensure utestAfterEach be executed regardless of a test failure

### DIFF
--- a/utest/shared/src/main/scala/utest/TestRunner.scala
+++ b/utest/shared/src/main/scala/utest/TestRunner.scala
@@ -75,10 +75,11 @@ object TestRunner {
                   case x: Future[_] => x
                   case notFuture => Future.successful(notFuture)
                 }
-                StackMarker.dropOutside{executor.utestAfterEach(path)}
                 res
               } catch {
                 case e: Throwable => Future.failed(e)
+              }finally {
+                StackMarker.dropOutside{executor.utestAfterEach(path)}
               }
             )
           } catch{

--- a/utest/shared/src/test/scala/test/utest/AfterEachOnFailureTest.scala
+++ b/utest/shared/src/test/scala/test/utest/AfterEachOnFailureTest.scala
@@ -19,15 +19,7 @@ object AfterEachOnFailureTest extends TestSuite {
     res.close()
   }
 
-  override def utestAfterAll(): Unit = {
-    println(s"Resource closed? ${res.isClosed}")
-    assert(res.isClosed)
-  }
-
   val tests = Tests{
-    'hello{
-      Future(0)
-    }
     'testFails {
       val innerTests = Tests{
         throw new java.lang.AssertionError("Fail")
@@ -35,6 +27,7 @@ object AfterEachOnFailureTest extends TestSuite {
       TestRunner.runAsync(innerTests, executor = this).map { results =>
         val leafResults = results.leaves.toSeq
         assert(leafResults(0).value.isFailure)
+        assert(res.isClosed)
         leafResults
       }
     }

--- a/utest/shared/src/test/scala/test/utest/AfterEachOnFailureTest.scala
+++ b/utest/shared/src/test/scala/test/utest/AfterEachOnFailureTest.scala
@@ -1,0 +1,49 @@
+package test.utest
+
+import utest._
+import utest.framework.ExecutionContext.RunNow
+
+import scala.concurrent.Future
+/**
+ * Put executor.utestAfterEach(path) into finally block to make sure it will be executed regardless of the test failing.
+ */
+object AfterEachOnFailureTest extends TestSuite {
+
+  private var res:SomeResource = _
+
+  override def utestBeforeEach(path: Seq[String]): Unit = {
+    res = new SomeResource //open resource
+  }
+
+  override def utestAfterEach(path: Seq[String]): Unit = {
+    res.close()
+  }
+
+  override def utestAfterAll(): Unit = {
+    println(s"Resource closed? ${res.isClosed}")
+    assert(res.isClosed)
+  }
+
+  val tests = Tests{
+    'hello{
+      Future(0)
+    }
+    'testFails {
+      val innerTests = Tests{
+        throw new java.lang.AssertionError("Fail")
+      }
+      TestRunner.runAsync(innerTests, executor = this).map { results =>
+        val leafResults = results.leaves.toSeq
+        assert(leafResults(0).value.isFailure)
+        leafResults
+      }
+    }
+  }
+
+
+
+  private class SomeResource extends AutoCloseable{
+    var isClosed:Boolean = false
+    override def close(): Unit = isClosed = true
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.0"
+version in ThisBuild := "0.6.1-SNAPSHOT"


### PR DESCRIPTION
Put `executor.utestAfterEach(path)` into `finally` block.

There is an outer enclosing `try-catch` block, so the change is safe.

Changed version to `0.6.1-SNAPSHOT`