### PR TITLE
Add support for Scala.js 1.0.0-M2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,23 @@ matrix:
       env: SCALAJS_VERSION="1.0.0-M1"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
+    - scala: 2.10.6
+      jdk: openjdk7
+      env: SCALAJS_VERSION="1.0.0-M2"
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
+
+    - scala: 2.11.11
+      env: SCALAJS_VERSION="1.0.0-M2"
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
+
+    - scala: 2.12.2
+      env: SCALAJS_VERSION="1.0.0-M2"
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
+
+    - scala: 2.13.0-M2
+      env: SCALAJS_VERSION="1.0.0-M2"
+      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
+
 # Taken from https://github.com/typelevel/cats/blob/master/.travis.yml
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
-    - scala: 2.13.0-M1
+    - scala: 2.13.0-M2
       env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
@@ -40,7 +40,7 @@ matrix:
       env: SCALAJS_VERSION="1.0.0-M1"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
-    - scala: 2.13.0-M1
+    - scala: 2.13.0-M2
       env: SCALAJS_VERSION="1.0.0-M1"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,11 @@ val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.19"
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"                  % "1.0.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release"              % "1.0.5")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"              % scalaJSVersion)
-addSbtPlugin("org.scala-native"  % "sbt-crossproject"         % "0.2.2")
-addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.3")
+addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.3" exclude("org.scala-native", "sbt-crossproject"))
 
 {
-  if (scalaJSVersion.startsWith("0.6."))
-    Seq(addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.2.2"))
-  else
+  if (scalaJSVersion == "1.0.0-M1")
     Nil
+  else
+    Seq(addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.0"))
 }

--- a/utest/jvm/src/test/scala-2.12/test/utest/FormatterTests.scala
+++ b/utest/jvm/src/test/scala-2.12/test/utest/FormatterTests.scala
@@ -8,7 +8,7 @@ import concurrent.ExecutionContext.Implicits.global
   */
 object FormatterTests extends utest.TestSuite {
   def trim(s: String): String = {
-    s.trim.lines.map(_.reverse.dropWhile(_ == ' ').reverse).mkString("\n")
+    s.trim.lines.map(_.reverse.dropWhile(_ == ' ').reverse).mkString("\n").replaceAll(" \\d+ms", "")
   }
   val tests = Tests{
     val tests = Tests {
@@ -28,147 +28,137 @@ object FormatterTests extends utest.TestSuite {
     }
 
     "simple" - {
-      var trimmedOutput0: String = ""
-      for(i <- 0 until 10) {
-        val boa = new java.io.ByteArrayOutputStream()
-        val printStream = new java.io.PrintStream(boa)
+      val boa = new java.io.ByteArrayOutputStream()
+      val printStream = new java.io.PrintStream(boa)
 
-        val results = TestRunner.runAndPrint(
-          tests,
-          "MyTestSuite",
-          printStream = printStream
-        )
+      val results = TestRunner.runAndPrint(
+        tests,
+        "MyTestSuite",
+        printStream = printStream
+      )
 
-        utest.framework.Formatter.formatSummary("MyTestSuite", results).foreach(printStream.println)
-        val trimmedOutput = trim(utest.ufansi.Str(new String(boa.toByteArray)).plainText)
-        trimmedOutput0 = trimmedOutput
-        // This is very confusing to debug, with all the inner and outer test
-        // traces being printed everywhere. Easier to paste it into the test `main`
-        // method, running it there, and seeing why it looks wrong
-        val expected = trim(
-          """X MyTestSuite.test1 0ms
-            |  java.lang.Exception: wrapper
-            |    test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:19)
-            |    test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
-            |  utest.AssertionError: try assert(x == 2)
-            |  x: Int = 1
-            |    utest.asserts.Asserts$.assertImpl(Asserts.scala:114)
-            |    test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:17)
-            |    test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
-            |+ MyTestSuite.test2 0ms  1
-            |X MyTestSuite.test3 0ms
-            |  java.lang.IndexOutOfBoundsException: 10
-            |    scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:63)
-            |    scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:61)
-            |    scala.collection.immutable.List.apply(List.scala:86)
-            |    test.utest.FormatterTests$.$anonfun$tests$6(FormatterTests.scala:26)
-            |- MyTestSuite 0ms
-            |  X test1 0ms
-            |    java.lang.Exception: wrapper
-            |      test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:19)
-            |      test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
-            |    utest.AssertionError: try assert(x == 2)
-            |    x: Int = 1
-            |      utest.asserts.Asserts$.assertImpl(Asserts.scala:114)
-            |      test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:17)
-            |      test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
-            |  + test2 0ms  1
-            |  X test3 0ms
-            |    java.lang.IndexOutOfBoundsException: 10
-            |      scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:63)
-            |      scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:61)
-            |      scala.collection.immutable.List.apply(List.scala:86)
-            |      test.utest.FormatterTests$.$anonfun$tests$6(FormatterTests.scala:26)
-          """.stripMargin
-        )
+      utest.framework.Formatter.formatSummary("MyTestSuite", results).foreach(printStream.println)
+      val trimmedOutput = trim(utest.ufansi.Str(new String(boa.toByteArray)).plainText)
 
-        // Warm up the code a few times first to ensure it finishes in 0ms per test
-        if (i == 9) assert(trimmedOutput == expected)
-      }
-      trimmedOutput0
+      // This is very confusing to debug, with all the inner and outer test
+      // traces being printed everywhere. Easier to paste it into the test `main`
+      // method, running it there, and seeing why it looks wrong
+      val expected = trim(
+        """X MyTestSuite.test1 0ms
+          |  java.lang.Exception: wrapper
+          |    test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:19)
+          |    test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
+          |  utest.AssertionError: try assert(x == 2)
+          |  x: Int = 1
+          |    utest.asserts.Asserts$.assertImpl(Asserts.scala:114)
+          |    test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:17)
+          |    test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
+          |+ MyTestSuite.test2 0ms  1
+          |X MyTestSuite.test3 0ms
+          |  java.lang.IndexOutOfBoundsException: 10
+          |    scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:63)
+          |    scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:61)
+          |    scala.collection.immutable.List.apply(List.scala:86)
+          |    test.utest.FormatterTests$.$anonfun$tests$6(FormatterTests.scala:26)
+          |- MyTestSuite 0ms
+          |  X test1 0ms
+          |    java.lang.Exception: wrapper
+          |      test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:19)
+          |      test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
+          |    utest.AssertionError: try assert(x == 2)
+          |    x: Int = 1
+          |      utest.asserts.Asserts$.assertImpl(Asserts.scala:114)
+          |      test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:17)
+          |      test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:17)
+          |  + test2 0ms  1
+          |  X test3 0ms
+          |    java.lang.IndexOutOfBoundsException: 10
+          |      scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:63)
+          |      scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:61)
+          |      scala.collection.immutable.List.apply(List.scala:86)
+          |      test.utest.FormatterTests$.$anonfun$tests$6(FormatterTests.scala:26)
+        """.stripMargin
+      )
+
+      assert(trimmedOutput == expected)
+      trimmedOutput
     }
 
     "wrapped" - {
-
-
-      var trimmedOutput0: String = ""
-      for(i <- 0 until 10) {
-        val boa = new java.io.ByteArrayOutputStream()
-        val printStream = new java.io.PrintStream(boa)
-        val wrappingFormatter = new utest.framework.Formatter{
-          override def formatWrapWidth = 50
-        }
-        val results = TestRunner.runAndPrint(
-          tests,
-          "MyTestSuite",
-          formatter = wrappingFormatter,
-          printStream = printStream
-        )
-        wrappingFormatter.formatSummary("MyTestSuite", results).foreach(printStream.println)
-        val trimmedOutput = trim(utest.ufansi.Str(new String(boa.toByteArray)).plainText)
-        trimmedOutput0 = trimmedOutput
-        // This is very confusing to debug, with all the inner and outer test
-        // traces being printed everywhere. Easier to paste it into the test `main`
-        // method, running it there, and seeing why it looks wrong
-        val expected = trim(
-          """X MyTestSuite.test1 0ms
-            |  java.lang.Exception: wrapper
-            |    test.utest.FormatterTests$.liftedTree1$1(Forma
-            |    tterTests.scala:19)
-            |    test.utest.FormatterTests$.$anonfun$tests$3(Fo
-            |    rmatterTests.scala:17)
-            |  utest.AssertionError: try assert(x == 2)
-            |  x: Int = 1
-            |    utest.asserts.Asserts$.assertImpl(Asserts.scal
-            |    a:114)
-            |    test.utest.FormatterTests$.liftedTree1$1(Forma
-            |    tterTests.scala:17)
-            |    test.utest.FormatterTests$.$anonfun$tests$3(Fo
-            |    rmatterTests.scala:17)
-            |+ MyTestSuite.test2 0ms  1
-            |X MyTestSuite.test3 0ms
-            |  java.lang.IndexOutOfBoundsException: 10
-            |    scala.collection.LinearSeqOptimized.apply(Line
-            |    arSeqOptimized.scala:63)
-            |    scala.collection.LinearSeqOptimized.apply$(Lin
-            |    earSeqOptimized.scala:61)
-            |    scala.collection.immutable.List.apply(List.sca
-            |    la:86)
-            |    test.utest.FormatterTests$.$anonfun$tests$6(Fo
-            |    rmatterTests.scala:26)
-            |- MyTestSuite 0ms
-            |  X test1 0ms
-            |    java.lang.Exception: wrapper
-            |      test.utest.FormatterTests$.liftedTree1$1(For
-            |      matterTests.scala:19)
-            |      test.utest.FormatterTests$.$anonfun$tests$3(
-            |      FormatterTests.scala:17)
-            |    utest.AssertionError: try assert(x == 2)
-            |    x: Int = 1
-            |      utest.asserts.Asserts$.assertImpl(Asserts.sc
-            |      ala:114)
-            |      test.utest.FormatterTests$.liftedTree1$1(For
-            |      matterTests.scala:17)
-            |      test.utest.FormatterTests$.$anonfun$tests$3(
-            |      FormatterTests.scala:17)
-            |  + test2 0ms  1
-            |  X test3 0ms
-            |    java.lang.IndexOutOfBoundsException: 10
-            |      scala.collection.LinearSeqOptimized.apply(Li
-            |      nearSeqOptimized.scala:63)
-            |      scala.collection.LinearSeqOptimized.apply$(L
-            |      inearSeqOptimized.scala:61)
-            |      scala.collection.immutable.List.apply(List.s
-            |      cala:86)
-            |      test.utest.FormatterTests$.$anonfun$tests$6(
-            |      FormatterTests.scala:26)
-          """.stripMargin
-        )
-
-        // Warm up the code a few times first to ensure it finishes in 0ms per test
-        if (i == 9) assert(trimmedOutput == expected)
+      val boa = new java.io.ByteArrayOutputStream()
+      val printStream = new java.io.PrintStream(boa)
+      val wrappingFormatter = new utest.framework.Formatter{
+        override def formatWrapWidth = 50
       }
-      trimmedOutput0
+      val results = TestRunner.runAndPrint(
+        tests,
+        "MyTestSuite",
+        formatter = wrappingFormatter,
+        printStream = printStream
+      )
+      wrappingFormatter.formatSummary("MyTestSuite", results).foreach(printStream.println)
+      val trimmedOutput = trim(utest.ufansi.Str(new String(boa.toByteArray)).plainText)
+
+      // This is very confusing to debug, with all the inner and outer test
+      // traces being printed everywhere. Easier to paste it into the test `main`
+      // method, running it there, and seeing why it looks wrong
+      val expected = trim(
+        """X MyTestSuite.test1 0ms
+          |  java.lang.Exception: wrapper
+          |    test.utest.FormatterTests$.liftedTree1$1(Forma
+          |    tterTests.scala:19)
+          |    test.utest.FormatterTests$.$anonfun$tests$3(Fo
+          |    rmatterTests.scala:17)
+          |  utest.AssertionError: try assert(x == 2)
+          |  x: Int = 1
+          |    utest.asserts.Asserts$.assertImpl(Asserts.scal
+          |    a:114)
+          |    test.utest.FormatterTests$.liftedTree1$1(Forma
+          |    tterTests.scala:17)
+          |    test.utest.FormatterTests$.$anonfun$tests$3(Fo
+          |    rmatterTests.scala:17)
+          |+ MyTestSuite.test2 0ms  1
+          |X MyTestSuite.test3 0ms
+          |  java.lang.IndexOutOfBoundsException: 10
+          |    scala.collection.LinearSeqOptimized.apply(Line
+          |    arSeqOptimized.scala:63)
+          |    scala.collection.LinearSeqOptimized.apply$(Lin
+          |    earSeqOptimized.scala:61)
+          |    scala.collection.immutable.List.apply(List.sca
+          |    la:86)
+          |    test.utest.FormatterTests$.$anonfun$tests$6(Fo
+          |    rmatterTests.scala:26)
+          |- MyTestSuite 0ms
+          |  X test1 0ms
+          |    java.lang.Exception: wrapper
+          |      test.utest.FormatterTests$.liftedTree1$1(For
+          |      matterTests.scala:19)
+          |      test.utest.FormatterTests$.$anonfun$tests$3(
+          |      FormatterTests.scala:17)
+          |    utest.AssertionError: try assert(x == 2)
+          |    x: Int = 1
+          |      utest.asserts.Asserts$.assertImpl(Asserts.sc
+          |      ala:114)
+          |      test.utest.FormatterTests$.liftedTree1$1(For
+          |      matterTests.scala:17)
+          |      test.utest.FormatterTests$.$anonfun$tests$3(
+          |      FormatterTests.scala:17)
+          |  + test2 0ms  1
+          |  X test3 0ms
+          |    java.lang.IndexOutOfBoundsException: 10
+          |      scala.collection.LinearSeqOptimized.apply(Li
+          |      nearSeqOptimized.scala:63)
+          |      scala.collection.LinearSeqOptimized.apply$(L
+          |      inearSeqOptimized.scala:61)
+          |      scala.collection.immutable.List.apply(List.s
+          |      cala:86)
+          |      test.utest.FormatterTests$.$anonfun$tests$6(
+          |      FormatterTests.scala:26)
+        """.stripMargin
+      )
+
+      assert(trimmedOutput == expected)
+      trimmedOutput
     }
   }
 }


### PR DESCRIPTION
Support for Scala.js 1.0.0-M1 should be probably be dropped soon-ish, but it might be a good idea to publish at least one version of uTest supporting both M1 and M2, to ease the transition for users (first upgrade to uTest 0.6.1, run the CI, then upgrade to Scala.js 1.0.0-M2, re-run the CI).