### PR TITLE
Move header printing

### DIFF
--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -38,8 +38,16 @@ abstract class BaseRunner(val args: Array[String],
                           val remoteArgs: Array[String],
                           testClassLoader: ClassLoader,
                           useSbtLoggers: Boolean,
-                          formatter: utest.framework.Formatter)
+                          formatter: utest.framework.Formatter,
+                          startHeader: Option[String => String])
                           extends sbt.testing.Runner{
+
+  def this(args: Array[String],
+    remoteArgs: Array[String],
+    testClassLoader: ClassLoader,
+    useSbtLoggers: Boolean,
+    formatter: utest.framework.Formatter) =
+      this(args, remoteArgs, testClassLoader, useSbtLoggers, formatter, None)
 
   lazy val path = args.headOption.filter(_(0) != '-')
   lazy val query = path
@@ -72,6 +80,8 @@ abstract class BaseRunner(val args: Array[String],
                suiteName: String,
                eventHandler: EventHandler,
                taskDef: TaskDef) = {
+
+    startHeader.foreach(h => println(h(path.fold("")(" " + _))))
 
     def handleEvent(op: OptionalThrowable,
                     st: Status,

--- a/utest/shared/src/main/scala/utest/runner/MasterRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/MasterRunner.scala
@@ -18,9 +18,8 @@ final class MasterRunner(args: Array[String],
                          failureHeader: String,
                          useSbtLoggers: Boolean,
                          formatter: utest.framework.Formatter)
-                         extends BaseRunner(args, remoteArgs, testClassLoader, useSbtLoggers, formatter){
+                         extends BaseRunner(args, remoteArgs, testClassLoader, useSbtLoggers, formatter, Some(startHeader)){
 
-  println(startHeader(path.fold("")(" " + _)))
   setup()
   val summaryOutputLines = new AtomicReference[List[String]](Nil)
   val success = new AtomicInteger(0)


### PR DESCRIPTION
I noticed that when running forked tests in sbt 1.0.4 that the
startHeader string was printed twice. This was because sbt calls
framework.runner once before and once after forking. To fix this
confusing behavior, I moved the printing of the start header into the
runSuite method of BaseRunner.