### PR TITLE
Configure Travis to release on tag push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ matrix:
       env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
-    - scala: 2.11.11
+    - scala: 2.11.12
       before_script:
       - curl https://raw.githubusercontent.com/scala-native/scala-native/master/bin/travis_setup.sh | bash -x
       sudo: required
       env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test utestNative/test
 
-    - scala: 2.12.2
+    - scala: 2.12.4
       env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
@@ -32,11 +32,11 @@ matrix:
       env: SCALAJS_VERSION="1.0.0-M1"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
-    - scala: 2.11.11
+    - scala: 2.11.12
       env: SCALAJS_VERSION="1.0.0-M1"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
-    - scala: 2.12.2
+    - scala: 2.12.4
       env: SCALAJS_VERSION="1.0.0-M1"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
@@ -49,11 +49,11 @@ matrix:
       env: SCALAJS_VERSION="1.0.0-M2"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
-    - scala: 2.11.11
+    - scala: 2.11.12
       env: SCALAJS_VERSION="1.0.0-M2"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 
-    - scala: 2.12.2
+    - scala: 2.12.4
       env: SCALAJS_VERSION="1.0.0-M2"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
   include:
     - scala: 2.10.6
       jdk: openjdk7
-      env:
-        - CI_PUBLISH: true
-        - SCALAJS_VERSION: "0.6.19"
+      env: CI_PUBLISH="true"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
     - scala: 2.11.12
@@ -21,50 +19,16 @@ matrix:
       - git fetch --tags
       - curl https://raw.githubusercontent.com/scala-native/scala-native/master/bin/travis_setup.sh | bash -x
       sudo: required
-      env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test utestNative/test
 
     - scala: 2.12.4
-      env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
     - scala: 2.13.0-M2
-      env: SCALAJS_VERSION="0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
-    - scala: 2.10.6
-      jdk: openjdk7
-      env: SCALAJS_VERSION="1.0.0-M1"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.11.12
-      env: SCALAJS_VERSION="1.0.0-M1"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.12.4
-      env: SCALAJS_VERSION="1.0.0-M1"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.13.0-M2
-      env: SCALAJS_VERSION="1.0.0-M1"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.10.6
-      jdk: openjdk7
-      env: SCALAJS_VERSION="1.0.0-M2"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.11.12
-      env: SCALAJS_VERSION="1.0.0-M2"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.12.4
-      env: SCALAJS_VERSION="1.0.0-M2"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
-
-    - scala: 2.13.0-M2
-      env: SCALAJS_VERSION="1.0.0-M2"
-      script: sbt ++$TRAVIS_SCALA_VERSION utestJS/test
+    - env: SCALAJS_VERSION="1.0.0-M2"
+      script: sbt "very utestJS/test"
 
 # Taken from https://github.com/typelevel/cats/blob/master/.travis.yml
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: scala
 sudo: required
 dist: trusty
 
+before_script:
+  - git fetch --tags
 jdk:
   - oraclejdk8
 
@@ -9,11 +11,14 @@ matrix:
   include:
     - scala: 2.10.6
       jdk: openjdk7
-      env: SCALAJS_VERSION="0.6.19"
+      env:
+        - CI_PUBLISH: true
+        - SCALAJS_VERSION: "0.6.19"
       script: sbt ++$TRAVIS_SCALA_VERSION utestJVM/test utestJS/test
 
     - scala: 2.11.12
       before_script:
+      - git fetch --tags
       - curl https://raw.githubusercontent.com/scala-native/scala-native/master/bin/travis_setup.sh | bash -x
       sudo: required
       env: SCALAJS_VERSION="0.6.19"
@@ -71,3 +76,5 @@ cache:
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/launchers
   - $HOME/.ivy2/cache
+after_success:
+- "./publishSigned-CI.sh"

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2", "2.13.0-M2
 updateOptions      in ThisBuild := (updateOptions in ThisBuild).value.withCachedResolution(true)
 incOptions         in ThisBuild := (incOptions in ThisBuild).value.withNameHashing(true).withLogRecompileOnMacro(false)
 //triggeredMessage   in ThisBuild := Watched.clearWhenTriggered
-releaseTagComment  in ThisBuild := s"v${(version in ThisBuild).value}"
-releaseVcsSign     in ThisBuild := true
 
 lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
@@ -33,7 +31,6 @@ lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     testFrameworks += new TestFramework("test.utest.CustomFramework"),
 
     // Release settings
-    releasePublishArtifactsAction := publishSigned.value,
     publishArtifact in Test := false,
     publishTo := {
       val nexus = "https://oss.sonatype.org/"
@@ -102,3 +99,13 @@ lazy val root = project.in(file("."))
     publishSigned := (),            // doesn't work
     packagedArtifacts := Map.empty) // doesn't work - https://github.com/sbt/sbt-pgp/issues/42
 
+// Settings for release from Travis on tag push
+inScope(Global)(
+  Seq(
+    credentials ++= (for {
+      username <- sys.env.get("SONATYPE_USERNAME")
+      password <- sys.env.get("SONATYPE_PASSWORD")
+    } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toList,
+    PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray())
+  )
+)

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ import sbt.addCompilerPlugin
 
 name               in ThisBuild := "utest"
 organization       in ThisBuild := "com.lihaoyi"
-scalaVersion       in ThisBuild := "2.12.2"
-crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2", "2.13.0-M2")
+scalaVersion       in ThisBuild := "2.12.4"
+crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.12", "2.12.4", "2.13.0-M2")
 updateOptions      in ThisBuild := (updateOptions in ThisBuild).value.withCachedResolution(true)
 incOptions         in ThisBuild := (incOptions in ThisBuild).value.withNameHashing(true).withLogRecompileOnMacro(false)
 //triggeredMessage   in ThisBuild := Watched.clearWhenTriggered

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.19"
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"                  % "1.0.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release"              % "1.0.5")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"              % scalaJSVersion)
-addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.3" exclude("org.scala-native", "sbt-crossproject"))
+addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.6" exclude("org.scala-native", "sbt-crossproject"))
 
 {
   if (scalaJSVersion == "1.0.0-M1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@
 // 0.6.20 breaks Java7 - https://github.com/scala-js/scala-js/issues/3128
 val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.19")
 
+addSbtPlugin("com.dwijnand"      % "sbt-dynver"               % "2.0.0")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"                  % "1.0.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release"              % "1.0.5")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"              % scalaJSVersion)
 addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.6" exclude("org.scala-native", "sbt-crossproject"))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,7 @@
 // 0.6.20 breaks Java7 - https://github.com/scala-js/scala-js/issues/3128
 val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.19")
 
+addSbtPlugin("com.eed3si9n"      % "sbt-doge"                 % "0.1.5")
 addSbtPlugin("com.dwijnand"      % "sbt-dynver"               % "2.0.0")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"                  % "1.0.1")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"              % scalaJSVersion)

--- a/publishSigned-CI.sh
+++ b/publishSigned-CI.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+if [[ "$TRAVIS_SECURE_ENV_VARS" == true && "$CI_PUBLISH" == true && -n "$TRAVIS_TAG"]]; then
+  echo "Publishing to sonatype..."
+  git log | head -n 20
+  echo "$PGP_SECRET" | base64 --decode | gpg --import
+  ./publishSigned.sh
+else
+  echo "Skipping publish, branch=$TRAVIS_BRANCH"
+fi

--- a/publishSigned.sh
+++ b/publishSigned.sh
@@ -12,10 +12,4 @@ sbt ++2.12.4 \
 sbt ++2.13.0-M2 \
     utestJS/publishSigned \
     utestJVM/publishSigned
-SCALAJS_VERSION=1.0.0-M1 sbt ++2.10.6 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M1 sbt ++2.11.12 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M1 sbt ++2.12.4 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M1 sbt ++2.13.0-M2 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M2 sbt ++2.11.12 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M2 sbt ++2.12.4 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M2 sbt ++2.13.0-M2 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M2 sbt "very utestJS/publishSigned"

--- a/publishSigned.sh
+++ b/publishSigned.sh
@@ -2,13 +2,20 @@
 sbt ++2.10.6 \
     utestJS/publishSigned \
     utestJVM/publishSigned
-sbt ++2.11.11 \
+sbt ++2.11.12 \
     utestJS/publishSigned \
     utestJVM/publishSigned \
     utestNative/publishSigned
-sbt ++2.12.3 \
+sbt ++2.12.4 \
     utestJS/publishSigned \
     utestJVM/publishSigned
-#SCALAJS_VERSION=1.0.0-M1 sbt ++2.10.6 utestJS/publishSigned
-#SCALAJS_VERSION=1.0.0-M1 sbt ++2.11.11 utestJS/publishSigned
-#SCALAJS_VERSION=1.0.0-M1 sbt ++2.12.3 utestJS/publishSigned
+sbt ++2.13.0-M2 \
+    utestJS/publishSigned \
+    utestJVM/publishSigned
+SCALAJS_VERSION=1.0.0-M1 sbt ++2.10.6 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M1 sbt ++2.11.12 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M1 sbt ++2.12.4 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M1 sbt ++2.13.0-M2 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M2 sbt ++2.11.12 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M2 sbt ++2.12.4 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M2 sbt ++2.13.0-M2 utestJS/publishSigned

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.2"
+version in ThisBuild := "0.6.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.6.3"


### PR DESCRIPTION
I'm using a similar setup my other projects and I've found the "release from CI on tag push" workflow to take a lot of stress out of the release process. The utest cross-build is at the moment extra tricky because of Scala.js 1.0 milestones so it's even better to automate releases.