### PR TITLE
eta expand explicitly (for Scala 2.13 compatibility)

### DIFF
--- a/utest/shared/src/main/scala/utest/runner/Framework.scala
+++ b/utest/shared/src/main/scala/utest/runner/Framework.scala
@@ -58,8 +58,8 @@ class Framework extends sbt.testing.Framework with framework.Formatter {
       args,
       remoteArgs,
       testClassLoader,
-      setup,
-      teardown,
+      setup _,
+      teardown _,
       showSummaryThreshold,
       startHeader,
       resultsHeader,
@@ -78,8 +78,8 @@ class Framework extends sbt.testing.Framework with framework.Formatter {
       remoteArgs,
       testClassLoader,
       send,
-      setup,
-      teardown,
+      setup _,
+      teardown _,
       useSbtLoggers,
       this
     )


### PR DESCRIPTION
implicit eta expansion on nullary methods has been deprecated
since Scala 2.12.0 and is removed in Scala 2.13

this came up in the Scala 2.13 community build