### PR TITLE
Synchronize calls to eventHandler.handle

### DIFF
--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -88,16 +88,18 @@ abstract class BaseRunner(val args: Array[String],
                     subpath: Seq[String],
                     millis: Long) = {
 
-      eventHandler.handle(new Event {
-        def fullyQualifiedName() = suiteName
-        def throwable() = op
-        def status() = st
-        def selector() = {
-          new NestedTestSelector(suiteName, subpath.mkString("."))
-        }
-        def fingerprint() = taskDef.fingerprint()
-        def duration() = millis
-      })
+      eventHandler.synchronized {
+        eventHandler.handle(new Event {
+          def fullyQualifiedName() = suiteName
+          def throwable() = op
+          def status() = st
+          def selector() = {
+            new NestedTestSelector(suiteName, subpath.mkString("."))
+          }
+          def fingerprint() = taskDef.fingerprint()
+          def duration() = millis
+        })
+      }
     }
 
     val suiteEither =


### PR DESCRIPTION
It turns out that having multiple async tests in a suite can cause the
tests to fail even when all of the individual tests pass. The issue is
that the eventHandle::handle method calls ArrayList::add, which is not
thread safe. If multiple threads call it at the same time, a null
object may be added to the result list that the child process sends back
to the parent. This manifests as an NPE in sbt.

This is really a bug in sbt, which should use a Vector instead of an
ArrayList, but I think the synchronization cost is likely minimal and
will fix the issue for all sbt versions.