### PR TITLE
Unconstrain formatWrapWidth by default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1334,6 +1334,7 @@ Changelog
 unreleased
 ----------
 - Bugfix where sometimes all tests would pass but report as failed (thanks @eatkins)
+- By default, don't cut-off and wrap output
 
 0.6.4
 -----

--- a/utest/shared/src/main/scala/utest/framework/Formatter.scala
+++ b/utest/shared/src/main/scala/utest/framework/Formatter.scala
@@ -14,7 +14,7 @@ trait Formatter {
 
   def formatColor: Boolean = true
   def formatTruncateHeight: Int = 15
-  def formatWrapWidth: Int = Int.MaxValue
+  def formatWrapWidth: Int = Int.MaxValue >> 1 // halving here to avoid overflows later
 
   def formatValue(x: Any) = testValueColor("" + x)
 

--- a/utest/shared/src/main/scala/utest/framework/Formatter.scala
+++ b/utest/shared/src/main/scala/utest/framework/Formatter.scala
@@ -14,7 +14,7 @@ trait Formatter {
 
   def formatColor: Boolean = true
   def formatTruncateHeight: Int = 15
-  def formatWrapWidth: Int = 100
+  def formatWrapWidth: Int = Int.MaxValue
 
   def formatValue(x: Any) = testValueColor("" + x)
 


### PR DESCRIPTION
`formatWrapWidth` is a nice feature but I strongly contest that it should be on by default. It's not true that the majority of users have a terminal set to exactly 100 chars and in most cases it just wastes vertical space leaving much horizontal space unused.