### PR TITLE
Use portable-scala-reflect instead of the deprecated TestUtils.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,12 +59,15 @@ lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 
 )
   .jsSettings(
-    libraryDependencies += "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion
+    libraryDependencies ++= Seq(
+      "org.scala-js" %% "scalajs-test-interface" % scalaJSVersion,
+      "org.portable-scala" %%% "portable-scala-reflect" % "0.1.0"
+    )
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
       "org.scala-sbt" % "test-interface" % "1.0",
-      "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided"
+      "org.portable-scala" %%% "portable-scala-reflect" % "0.1.0"
     ),
     resolvers += Resolver.sonatypeRepo("snapshots")
   )

--- a/utest/js/src/main/scala/utest/PlatformShims.scala
+++ b/utest/js/src/main/scala/utest/PlatformShims.scala
@@ -1,6 +1,7 @@
 package utest
 
 import scala.concurrent.Future
+import org.portablescala.reflect.Reflect
 
 /**
  * Platform specific stuff that differs between JVM and JS
@@ -13,5 +14,15 @@ object PlatformShims {
         "Test that returns Future must be run asynchronously in Scala.js, see TestTreeSeq::runAsync"
       )
     }
+  }
+
+  type EnableReflectiveInstantiation =
+    org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
+  def loadModule(name: String, loader: ClassLoader): Any = {
+    Reflect
+      .lookupLoadableModuleClass(name + "$", loader)
+      .getOrElse(throw new ClassNotFoundException(name))
+      .loadModule()
   }
 }

--- a/utest/jvm/src/main/scala/utest/PlatformShims.scala
+++ b/utest/jvm/src/main/scala/utest/PlatformShims.scala
@@ -1,13 +1,22 @@
 package utest
 
 import scala.concurrent.{Await, Future}
-import scala.util.{Failure, Success}
 import concurrent.duration._
-import java.io.{PrintWriter, StringWriter}
+import org.portablescala.reflect.Reflect
 
 /**
  * Platform specific stuff that differs between JVM and JS
  */
 object PlatformShims {
   def await[T](f: Future[T]): T = Await.result(f, 10.hours)
+
+  type EnableReflectiveInstantiation =
+    org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
+  def loadModule(name: String, loader: ClassLoader): Any = {
+    Reflect
+      .lookupLoadableModuleClass(name + "$", loader)
+      .getOrElse(throw new ClassNotFoundException(name))
+      .loadModule()
+  }
 }

--- a/utest/native/src/main/scala/utest/PlatformShims.scala
+++ b/utest/native/src/main/scala/utest/PlatformShims.scala
@@ -3,6 +3,7 @@ package utest
 // Taken from the implementation for JS
 
 import scala.concurrent.Future
+import org.scalajs.testinterface.TestUtils
 
 /**
  * Platform specific stuff that differs between JVM and Native
@@ -16,4 +17,10 @@ object PlatformShims {
       )
     }
   }
+
+  type EnableReflectiveInstantiation =
+    scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+
+  def loadModule(name: String, loader: ClassLoader): Any =
+    TestUtils.loadModule(name, loader)
 }

--- a/utest/shared/src/main/scala/utest/TestSuite.scala
+++ b/utest/shared/src/main/scala/utest/TestSuite.scala
@@ -8,7 +8,8 @@ import utest.framework.Formatter
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.macros.Context
 import scala.language.experimental.macros
-import scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+
+import PlatformShims.EnableReflectiveInstantiation
 
 /**
  * Marker class used to mark an `object` as something containing tests. Used

--- a/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
+++ b/utest/shared/src/main/scala/utest/runner/BaseRunner.scala
@@ -4,7 +4,6 @@ package runner
 import sbt.testing._
 
 import scala.util.Failure
-import org.scalajs.testinterface.TestUtils
 import utest.framework.{StackMarker, Tree}
 object BaseRunner{
   /**
@@ -106,7 +105,7 @@ abstract class BaseRunner(val args: Array[String],
       try {
         Right(
           StackMarker.dropOutside(
-            TestUtils.loadModule(suiteName, testClassLoader).asInstanceOf[TestSuite]
+            PlatformShims.loadModule(suiteName, testClassLoader).asInstanceOf[TestSuite]
           )
         )
       } catch{case e: Throwable => Left(e)}


### PR DESCRIPTION
`TestUtils` is deprecated in Scala.js 0.6.25. It has been replaced by the more general portable-scala-reflect library. This commit migrates to using the latter.

Since portable-scala-reflect does not support Scala Native yet, we need a bit more stuff in `PlatformShims`. These won't be necessary when Scala Native implements https://github.com/scala-native/scala-native/issues/1279 and portable-scala-reflect starts supporting Scala Native.

The change in depth of stack traces that are ignored is due to the fact that `TestUtils.loadModule` was a macro that forced inlining of its implementation, whereas `PlatformShims.loadModule` does not do that.