### PR TITLE
Update CI release scripts to publish for 2.13.0-M5

### DIFF
--- a/bin/publishSigned.sh
+++ b/bin/publishSigned.sh
@@ -9,10 +9,10 @@ sbt ++2.11.12 \
 sbt ++2.12.6 \
     utestJS/publishSigned \
     utestJVM/publishSigned
-sbt ++2.13.0-M3 \
+sbt ++2.13.0-M5 \
     utestJS/publishSigned \
     utestJVM/publishSigned
 
 SCALAJS_VERSION=1.0.0-M5 sbt ++2.11.12 utestJS/publishSigned
 SCALAJS_VERSION=1.0.0-M5 sbt ++2.12.6 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M5 sbt ++2.13.0-M3 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M5 sbt ++2.13.0-M5 utestJS/publishSigned

--- a/bin/testRelease.sh
+++ b/bin/testRelease.sh
@@ -6,7 +6,7 @@ coursier fetch com.lihaoyi:utest_2.10:$VERSION
 coursier fetch com.lihaoyi:utest_2.11:$VERSION
 coursier fetch com.lihaoyi:utest_2.12:$VERSION
 coursier fetch com.lihaoyi:utest_2.13.0-M5:$VERSION
-coursier fetch com.lihaoyi:utest_2.13.0-M7:$VERSION
+coursier fetch com.lihaoyi:utest_2.13.0-M5:$VERSION
 coursier fetch com.lihaoyi:utest_native0.3_2.11:$VERSION
 coursier fetch com.lihaoyi:utest_sjs0.6_2.10:$VERSION
 coursier fetch com.lihaoyi:utest_sjs0.6_2.11:$VERSION

--- a/bin/testRelease.sh
+++ b/bin/testRelease.sh
@@ -5,14 +5,14 @@ VERSION=$1
 coursier fetch com.lihaoyi:utest_2.10:$VERSION
 coursier fetch com.lihaoyi:utest_2.11:$VERSION
 coursier fetch com.lihaoyi:utest_2.12:$VERSION
-coursier fetch com.lihaoyi:utest_2.13.0-M3:$VERSION
 coursier fetch com.lihaoyi:utest_2.13.0-M5:$VERSION
+coursier fetch com.lihaoyi:utest_2.13.0-M7:$VERSION
 coursier fetch com.lihaoyi:utest_native0.3_2.11:$VERSION
 coursier fetch com.lihaoyi:utest_sjs0.6_2.10:$VERSION
 coursier fetch com.lihaoyi:utest_sjs0.6_2.11:$VERSION
 coursier fetch com.lihaoyi:utest_sjs0.6_2.12:$VERSION
-coursier fetch com.lihaoyi:utest_sjs0.6_2.13.0-M3:$VERSION
+coursier fetch com.lihaoyi:utest_sjs0.6_2.13.0-M5:$VERSION
 coursier fetch com.lihaoyi:utest_sjs0.6_2.13.0-M5:$VERSION
 coursier fetch com.lihaoyi:utest_sjs1.0.0-M5_2.11:$VERSION
 coursier fetch com.lihaoyi:utest_sjs1.0.0-M5_2.12:$VERSION
-coursier fetch com.lihaoyi:utest_sjs1.0.0-M5_2.13.0-M3:$VERSION
+coursier fetch com.lihaoyi:utest_sjs1.0.0-M5_2.13.0-M5:$VERSION

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbt.addCompilerPlugin
 name               in ThisBuild := "utest"
 organization       in ThisBuild := "com.lihaoyi"
 scalaVersion       in ThisBuild := "2.12.6"
-crossScalaVersions in ThisBuild := Seq("2.10.7", "2.11.12", "2.12.6", "2.13.0-M3", "2.13.0-M5")
+crossScalaVersions in ThisBuild := Seq("2.10.7", "2.11.12", "2.12.6", "2.13.0-M5")
 updateOptions      in ThisBuild := (updateOptions in ThisBuild).value.withCachedResolution(true)
 incOptions         in ThisBuild := (incOptions in ThisBuild).value.withLogRecompileOnMacro(false)
 //triggeredMessage   in ThisBuild := Watched.clearWhenTriggered


### PR DESCRIPTION
Drops 2.13.0-M3 from the build itself, if there is demand for it I can
cut a manual release from my local machine.