### PR TITLE
Use IndexedSeq instead of Array

### DIFF
--- a/utest/shared/src/main/scala/utest/Tests.scala
+++ b/utest/shared/src/main/scala/utest/Tests.scala
@@ -114,7 +114,7 @@ object Tests{
           ..$normal2
           ${
           if (childCallTrees.isEmpty) q"_root_.scala.Left($last)"
-          else q"$last; _root_.scala.Right(Array(..$childCallTrees))"
+          else q"$last; _root_.scala.Right(_root_.scala.collection.immutable.IndexedSeq(..$childCallTrees))"
         }
         })
       """


### PR DESCRIPTION
With scala 2.13.0-M5, I was seeing deprecation warnings about the
implicit conversion from Array to IndexedSeq. That conversion copies so
it's inefficient in general. It seems better to just explicitly
construct an IndexedSeq instead of relying on that conversion.