### PR TITLE
enable feature warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ incOptions         in ThisBuild := (incOptions in ThisBuild).value.withLogRecomp
 lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     name                  := "utest",
-    scalacOptions         := Seq("-Ywarn-dead-code"),
+    scalacOptions         := Seq("-Ywarn-dead-code", "-feature"),
     scalacOptions in Test -= "-Ywarn-dead-code",
     libraryDependencies  ++= macroDependencies(scalaVersion.value),
     scalacOptions        ++= (scalaVersion.value match {

--- a/utest/shared/src/main/scala/utest/ufansi/Fansi.scala
+++ b/utest/shared/src/main/scala/utest/ufansi/Fansi.scala
@@ -4,6 +4,7 @@ package ufansi
 
 import java.util
 
+import scala.language.implicitConversions
 import scala.annotation.tailrec
 import scala.collection.mutable
 
@@ -687,7 +688,7 @@ sealed abstract class Category(val offset: Int, val width: Int)(implicit catName
     if (escapeOpt.isDefined) escapeOpt.get
     else ""
   }
-  def lookupAttr(applyState: Long) = lookupAttrTable(applyState >> offset toInt)
+  def lookupAttr(applyState: Long) = lookupAttrTable((applyState >> offset).toInt)
 
   // Allows fast lookup of categories based on the desired applyState
   protected[this] def lookupTableWidth = 1 << width
@@ -695,7 +696,7 @@ sealed abstract class Category(val offset: Int, val width: Int)(implicit catName
   protected[this] lazy val lookupAttrTable = {
     val arr = new Array[Attr](lookupTableWidth)
     for(attr <- all){
-      arr(attr.applyMask >> offset toInt) = attr
+      arr((attr.applyMask >> offset).toInt) = attr
     }
     arr
   }

--- a/utest/shared/src/test/scala/test/utest/FrameworkAsyncTests.scala
+++ b/utest/shared/src/test/scala/test/utest/FrameworkAsyncTests.scala
@@ -17,7 +17,7 @@ object FrameworkAsyncTests extends TestSuite {
       val tests = Tests {
         "testSuccessAsync" - {
           val p = concurrent.Promise[Int]
-          test.utest.Scheduler.scheduleOnce(2 seconds)(p.success(123))
+          test.utest.Scheduler.scheduleOnce(2.seconds)(p.success(123))
 
           // Not supported by Scala Native at the moment.
           // Futures are completed either at the end of the `main` function or immediately.
@@ -28,7 +28,7 @@ object FrameworkAsyncTests extends TestSuite {
         }
         "testFailAsync" - {
           val p = concurrent.Promise[Int]
-          test.utest.Scheduler.scheduleOnce(2 seconds)(p.failure(new Exception("Boom")))
+          test.utest.Scheduler.scheduleOnce(2.seconds)(p.failure(new Exception("Boom")))
 
           // Not supported by Scala Native at the moment.
           // Futures are completed either at the end of the `main` function or immediately.


### PR DESCRIPTION
and fix the warnings incurred, too

the specific motivation here is that the postfixOps import will
actually be required as of 2.13.0-RC1, it won't be just a warning
anymore. this is already happening in the Scala 2.13 community build

but also, this is just good cleanup anyway