### PR TITLE
Scala-2.13.0-RC2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - scala: 2.12.8
       script: sbt ++$TRAVIS_SCALA_VERSION! utestJVM/test utestJS/test
 
-    - scala: 2.13.0-RC1
+    - scala: 2.13.0-RC2
       script: sbt ++$TRAVIS_SCALA_VERSION! utestJVM/test utestJS/test
 
     - env: SCALAJS_VERSION="1.0.0-M7"
@@ -39,7 +39,7 @@ matrix:
       script: sbt ++$TRAVIS_SCALA_VERSION! utestJS/test
 
     - env: SCALAJS_VERSION="1.0.0-M7"
-      scala: 2.13.0-RC1
+      scala: 2.13.0-RC2
       script: sbt ++$TRAVIS_SCALA_VERSION! utestJS/test
 
 # Taken from https://github.com/typelevel/cats/blob/master/.travis.yml

--- a/bin/publishSigned.sh
+++ b/bin/publishSigned.sh
@@ -9,10 +9,10 @@ sbt ++2.11.12 \
 sbt ++2.12.8 \
     utestJS/publishSigned \
     utestJVM/publishSigned
-sbt ++2.13.0-RC1 \
+sbt ++2.13.0-RC2 \
     utestJS/publishSigned \
     utestJVM/publishSigned
 
 SCALAJS_VERSION=1.0.0-M7 sbt ++2.11.12 utestJS/publishSigned
 SCALAJS_VERSION=1.0.0-M7 sbt ++2.12.8 utestJS/publishSigned
-SCALAJS_VERSION=1.0.0-M7 sbt ++2.13.0-RC1 utestJS/publishSigned
+SCALAJS_VERSION=1.0.0-M7 sbt ++2.13.0-RC2 utestJS/publishSigned

--- a/bin/testRelease.sh
+++ b/bin/testRelease.sh
@@ -6,15 +6,15 @@ coursier fetch \
   com.lihaoyi:utest_2.10:$VERSION \
   com.lihaoyi:utest_2.11:$VERSION \
   com.lihaoyi:utest_2.12:$VERSION \
-  com.lihaoyi:utest_2.13.0-RC1:$VERSION \
-  com.lihaoyi:utest_2.13.0-RC1:$VERSION \
+  com.lihaoyi:utest_2.13.0-RC2:$VERSION \
+  com.lihaoyi:utest_2.13.0-RC2:$VERSION \
   com.lihaoyi:utest_native0.3_2.11:$VERSION \
   com.lihaoyi:utest_sjs0.6_2.10:$VERSION \
   com.lihaoyi:utest_sjs0.6_2.11:$VERSION \
   com.lihaoyi:utest_sjs0.6_2.12:$VERSION \
-  com.lihaoyi:utest_sjs0.6_2.13.0-RC1:$VERSION \
-  com.lihaoyi:utest_sjs0.6_2.13.0-RC1:$VERSION \
+  com.lihaoyi:utest_sjs0.6_2.13.0-RC2:$VERSION \
+  com.lihaoyi:utest_sjs0.6_2.13.0-RC2:$VERSION \
   com.lihaoyi:utest_sjs1.0.0-M7_2.11:$VERSION \
   com.lihaoyi:utest_sjs1.0.0-M7_2.12:$VERSION \
-  com.lihaoyi:utest_sjs1.0.0-M7_2.13.0-RC1:$VERSION \
+  com.lihaoyi:utest_sjs1.0.0-M7_2.13.0-RC2:$VERSION \
   -r sonatype:public

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbt.librarymanagement.{SemanticSelector, VersionNumber}
 name               in ThisBuild := "utest"
 organization       in ThisBuild := "com.lihaoyi"
 scalaVersion       in ThisBuild := "2.12.8"
-crossScalaVersions in ThisBuild := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC1")
+crossScalaVersions in ThisBuild := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC2")
 updateOptions      in ThisBuild := (updateOptions in ThisBuild).value.withCachedResolution(true)
 incOptions         in ThisBuild := (incOptions in ThisBuild).value.withLogRecompileOnMacro(false)
 //triggeredMessage   in ThisBuild := Watched.clearWhenTriggered
@@ -30,7 +30,7 @@ lazy val utest = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       baseDirectory.value/".."/"shared"/"src"/"main"/v
     },
     unmanagedSourceDirectories in Compile ++= {
-      if (VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector("<2.13.0-RC1"))) {
+      if (VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector("<2.13.0-RC2"))) {
         baseDirectory.value/".."/"shared"/"src"/"main"/"scala-pre-2.13" :: Nil
       } else {
         Nil


### PR DESCRIPTION
Drops 2.13.0-RC1 for 2.13.0-RC2.  We could keep them both, but most libraries are dropping RC1.