### PR TITLE
TestPath macro use Seq instead of Array (2.13 Deprecation Warning)

### DIFF
--- a/utest/src/utest/Tests.scala
+++ b/utest/src/utest/Tests.scala
@@ -78,7 +78,7 @@ object Tests{
           override def transform(t: c.Tree) = {
             t match{
               case q"framework.this.TestPath.synthetic" =>
-                c.typeCheck(q"_root_.utest.framework.TestPath(_root_.scala.Array(..$path))")
+                c.typeCheck(q"_root_.utest.framework.TestPath(_root_.scala.Seq(..$path))")
               case _ => super.transform(t)
             }
           }


### PR DESCRIPTION
Hi Folks,

Thanks for the great library!

This change is to avoid the 2.13 deprecation warning for TestPath macros.

```
method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
```

[`TestPath` accepts a `Seq`](https://github.com/lihaoyi/utest/blob/374e408119efffae085e9e0d53dff3bebb9253dc/utest/src/utest/framework/Model.scala#L10), so it probably makes sense to switch anyway.

Please let me know if you want any further changes.