### PR TITLE
Upgrade to Scala.js 1.0.0.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -97,7 +97,7 @@ object utest extends Module {
     }
   }
 
-  object native extends Cross[NativeUtestModule](("2.11.12", "0.3.8")/*, ("2.11.12", "0.4.0-M2")*/)
+  /*object native extends Cross[NativeUtestModule](("2.11.12", "0.3.8")/*, ("2.11.12", "0.4.0-M2")*/)
   class NativeUtestModule(val crossScalaVersion: String, crossScalaNativeVersion: String)
     extends UtestMainModule with ScalaNativeModule with UtestModule {
     def offset = os.up
@@ -111,5 +111,5 @@ object utest extends Module {
       def offset = os.up
       val crossScalaVersion = NativeUtestModule.this.crossScalaVersion
     }
-  }
+  }*/
 }

--- a/build.sc
+++ b/build.sc
@@ -80,7 +80,7 @@ object utest extends Module {
   }
 
   object js extends Cross[JsUtestModule](
-    ("2.12.10", "0.6.31"), ("2.13.1", "0.6.31"), ("2.12.10", "1.0.0-RC2"), ("2.13.1", "1.0.0-RC2")
+    ("2.12.10", "0.6.31"), ("2.13.1", "0.6.31"), ("2.12.10", "1.0.0"), ("2.13.1", "1.0.0")
   )
   class JsUtestModule(val crossScalaVersion: String, crossJSVersion: String)
     extends UtestMainModule with ScalaJSModule with UtestModule {

--- a/mill
+++ b/mill
@@ -3,7 +3,8 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.5.3
+DEFAULT_MILL_VERSION=0.6.0-15-ee0405
+
 
 set -e
 

--- a/readme.md
+++ b/readme.md
@@ -1329,6 +1329,11 @@ libraries are currently at.
 Changelog
 =========
 
+0.7.4 (ongoing)
+---------------
+
+- Add support for Scala.js 1.0.0
+
 0.7.3
 -----
 


### PR DESCRIPTION
@lihaoyi I will need a version of uTest published for Scala.js 1.0.0 in order to update the basic tutorial on the official website. So this is a blocker for the official announcement. Nothing urgent, but I would very much appreciate it if it can happen within a week or two.