### PR TITLE
Support Async tests in Scala Native

### DIFF
--- a/utest/js/src/utest/PlatformShims.scala
+++ b/utest/js/src/utest/PlatformShims.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Future
 import org.portablescala.reflect.Reflect
 
 /**
- * Platform specific stuff that differs between JVM and JS
+ * Platform specific stuff that differs between JVM, JS and Native
  */
 object PlatformShims {
   def await[T](f: Future[T]): T = {

--- a/utest/jvm/src/utest/PlatformShims.scala
+++ b/utest/jvm/src/utest/PlatformShims.scala
@@ -4,10 +4,10 @@ import scala.concurrent.{Await, Future}
 import concurrent.duration._
 
 /**
- * Platform specific stuff that differs between JVM and JS
+ * Platform specific stuff that differs between JVM, JS and Native
  */
 object PlatformShims extends PlatformShimsVersionSpecific {
-  def await[T](f: Future[T]): T = Await.result(f, 10.hours)
+  def await[T](f: Future[T]): T = Await.result(f, Duration.Inf)
 
   def loadModule(name: String, loader: ClassLoader): Any =
     Reflect

--- a/utest/native/src/utest/PlatformShims.scala
+++ b/utest/native/src/utest/PlatformShims.scala
@@ -6,10 +6,11 @@ import scala.concurrent.Future
 import org.scalajs.testinterface.TestUtils
 
 /**
- * Platform specific stuff that differs between JVM and Native
+ * Platform specific stuff that differs between JVM, JS and Native
  */
 object PlatformShims {
   def await[T](f: Future[T]): T = {
+    scala.scalanative.runtime.loop()
     f.value match {
       case Some(v) => v.get
       case None => throw new IllegalStateException(

--- a/utest/native/test/src/test/utest/Scheduler.scala
+++ b/utest/native/test/src/test/utest/Scheduler.scala
@@ -1,7 +1,7 @@
 package test.utest
 
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 object Scheduler {
   // Will execute immediately, because we cannot currenly schedule
@@ -10,7 +10,8 @@ object Scheduler {
   def scheduleOnce[T](interval: FiniteDuration)
                      (thunk: => T)
                      (implicit executor: ExecutionContext): Unit = {
-    Future { thunk }
-    ()
+    executor.execute(new Runnable {
+      def run(): Unit = thunk
+    })
   }
 }

--- a/utest/src/utest/runner/Task.scala
+++ b/utest/src/utest/runner/Task.scala
@@ -17,7 +17,7 @@ class Task(val taskDef: TaskDef,
   def tags(): Array[String] = Array()
 
   def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[testing.Task] = {
-    Await.result(runUTestTask(loggers, eventHandler), Duration.Inf)
+    PlatformShims.await(runUTestTask(loggers, eventHandler))
     Array()
   }
 


### PR DESCRIPTION
This PR allows to execute tests that return `Future`s using Scala Native's test runner.

The only not properly supported part is the `Schedule. scheduleOnce` function which would require some event loop support. I didn't want utest to depend of [scala-native-loop](https://github.com/scala-native/scala-native-loop) that offers a way to asynchronously schedule timers on top of libuv. When scala-native-loop API becomes stable we can reconsider if that makes sense.