### PR TITLE
Add jvm scala 2.11

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -57,7 +57,7 @@ trait UtestTestModule extends ScalaModule with TestModule {
 
 object utest extends Module {
   val dottyVersion = Option(sys.props("dottyVersion"))
-  object jvm extends Cross[JvmUtestModule]((List("2.12.8", "2.13.0", "0.27.0-RC1") ++ dottyVersion): _*)
+  object jvm extends Cross[JvmUtestModule]((List("2.11.12", "2.12.8", "2.13.0", "0.27.0-RC1") ++ dottyVersion): _*)
   class JvmUtestModule(val crossScalaVersion: String)
     extends UtestMainModule with ScalaModule with UtestModule {
     def ivyDeps = Agg(


### PR DESCRIPTION
> Supports every version of Scala under the sun

-- https://github.com/lihaoyi/utest/blob/master/readme.md#%C2%B5test-072--

I still need to cross build libraries for 2.11. I've been itching to use utest, but can't use the latest `test("foo")` syntax with 0.6.8, which seems to be [the last release for 2.11](https://mvnrepository.com/artifact/com.lihaoyi/utest).

Can I get a cross build, please? Everything seems to pass as-is.