### PR TITLE
Fix failed assertion linenumbers

### DIFF
--- a/utest/test/src-jvm/test/utest/LineNumbersTests.scala
+++ b/utest/test/src-jvm/test/utest/LineNumbersTests.scala
@@ -36,13 +36,60 @@ object LineNumbersTests extends utest.TestSuite {
     test("test7") {
       val result = "testing".trim()
       assert(result == "notMatching")
-      test("innerTest5") {
+      test("innerTest55") {
         assert(1 == 1)
       }
       result
     }
+    test("test8") {
+      val result = "testing".trim()
+      val blockWithFailingAssert = {
+        assert("matching" == "notMatching")
+        assert(1 == 2)
+      }
+      test("innerTest55") {
+        assert(1 == 1)
+      }
+      result
+    }
+    test("test9") {
+      val result = "testing".trim()
+      val methodWithFailingAssert = println(
+        assert(1 == 2)
+      )
+      test("innerTest55") {
+        assert(1 == 1)
+      }
+      result
+    }
+    test("test10") - Obj(1).method{ x =>
+        assert(x.elem == "notMatching")
+    }
+    test("test11"){
+        def xx(body: Int)(rest:Int) = body == rest
+        val partiallyApplied = xx{
+          assert(1 == 2)
+          1
+        } _
+
+        ()
+    }
+    test("test12"){
+        def xx(body: => Int)(rest:Int) = body == rest
+        val partiallyAppliedByName = xx{
+          assert(1 == 2)
+          1
+        } _
+
+        partiallyAppliedByName(2)
+        ()
+    }
   }
 
+  private case class Obj(arg:Int) {
+    def method[T](tester: Obj => T):T = tester(this)
+    val elem = "elem"
+  }
   val testBody = {
 
     val results = TestRunner.run(
@@ -59,6 +106,11 @@ object LineNumbersTests extends utest.TestSuite {
       stackTraceLinesFromThisFile(4).exists(_.getLineNumber == 28),
       stackTraceLinesFromThisFile(5).exists(_.getLineNumber == 33),
       stackTraceLinesFromThisFile(6).exists(_.getLineNumber == 38),
+      stackTraceLinesFromThisFile(7).exists(_.getLineNumber == 47),
+      stackTraceLinesFromThisFile(8).exists(_.getLineNumber == 58),
+      stackTraceLinesFromThisFile(9).exists(_.getLineNumber == 66),
+      stackTraceLinesFromThisFile(10).exists(_.getLineNumber == 71),
+      stackTraceLinesFromThisFile(11).exists(_.getLineNumber == 80),
     )
 
   }


### PR DESCRIPTION
This takes into account any expression used as test body, and transforms its tree in order to wrap every utest.assert expressions in Inlined